### PR TITLE
fix(core,sqlite,app): attribute value schema

### DIFF
--- a/.changeset/hungry-islands-accept.md
+++ b/.changeset/hungry-islands-accept.md
@@ -1,0 +1,6 @@
+---
+"@kopai/sqlite-datasource": minor
+"@kopai/core": minor
+---
+
+Extended support for attribute values to include arrays of strings, numbers, and booleans alongside primitive values, broadening the allowed data types for OpenTelemetry resource and span attributes.

--- a/packages/core/src/denormalized-signals-zod.ts
+++ b/packages/core/src/denormalized-signals-zod.ts
@@ -1,6 +1,13 @@
 import { z } from "zod";
 
-const attributeValue = z.union([z.string(), z.number(), z.boolean()]);
+const attributeValue = z.union([
+  z.string(),
+  z.number(),
+  z.boolean(),
+  z.array(z.string()),
+  z.array(z.number()),
+  z.array(z.boolean()),
+]);
 
 export const otelTracesSchema = z.object({
   // Required fields


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended support for attribute values to include arrays of strings, numbers, and booleans alongside primitive values, broadening allowed data types for OpenTelemetry resource, span, metric, and exemplar attributes.

* **Tests**
  * Added test coverage to verify array-type attribute values are correctly preserved when writing and reading traces.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->