### PR TITLE
fix(cli): add url to --help everywhere

### DIFF
--- a/.changeset/wicked-poets-fail.md
+++ b/.changeset/wicked-poets-fail.md
@@ -1,0 +1,5 @@
+---
+"@kopai/cli": patch
+---
+
+Improve --help

--- a/.changeset/wicked-poets-fail.md
+++ b/.changeset/wicked-poets-fail.md
@@ -2,4 +2,4 @@
 "@kopai/cli": patch
 ---
 
-Improve --help
+Promote --url, --token, --config, --timeout to top-level and all subcommands; add usage examples to --help

--- a/packages/cli/src/client.ts
+++ b/packages/cli/src/client.ts
@@ -1,5 +1,14 @@
+import type { Command } from "commander";
 import { KopaiClient } from "@kopai/sdk";
 import { loadConfig } from "./config.js";
+
+export function withConnectionOptions<T extends Command>(cmd: T): T {
+  return cmd
+    .option("--url <url>", "API base URL")
+    .option("--token <token>", "Auth token")
+    .option("-c, --config <path>", "Config file path")
+    .option("--timeout <ms>", "Request timeout") as T;
+}
 
 export interface ClientOptions {
   config?: string;

--- a/packages/cli/src/client.ts
+++ b/packages/cli/src/client.ts
@@ -25,10 +25,13 @@ export function createClient(opts: ClientOptions): KopaiClient {
   const url = opts.url ?? fileConfig.url ?? DEFAULT_URL;
   const token = opts.token ?? fileConfig.token;
 
+  const timeout =
+    opts.timeout != null ? parseInt(String(opts.timeout), 10) : undefined;
+
   return new KopaiClient({
     baseUrl: url,
     token,
-    timeout: opts.timeout,
+    timeout: Number.isNaN(timeout) ? undefined : timeout,
   });
 }
 

--- a/packages/cli/src/commands/logs.ts
+++ b/packages/cli/src/commands/logs.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import {
   createClient,
   parseAttributes,
+  withConnectionOptions,
   type ClientOptions,
 } from "../client.js";
 import { detectFormat, output, outputError, parseFields } from "../output.js";
@@ -30,82 +31,79 @@ interface LogsSearchOptions extends ClientOptions {
 export function createLogsCommand(): Command {
   const logs = new Command("logs").description("Query logs");
 
-  logs
-    .command("search")
-    .description("Search logs")
-    .option("-j, --json", "JSON output")
-    .option("-t, --table", "Table output")
-    .option("-f, --fields <fields>", "Comma-separated fields to include")
-    .option("-l, --limit <n>", "Max results")
-    .option("--trace-id <id>", "Filter by trace ID")
-    .option("--span-id <id>", "Filter by span ID")
-    .option("-s, --service <name>", "Filter by service name")
-    .option("--scope <name>", "Filter by scope name")
-    .option("--severity-text <level>", "Filter by severity text")
-    .option("--severity-min <n>", "Min severity number")
-    .option("--severity-max <n>", "Max severity number")
-    .option("-b, --body <text>", "Filter by body contains")
-    .option("--timestamp-min <ns>", "Min timestamp (nanoseconds)")
-    .option("--timestamp-max <ns>", "Max timestamp (nanoseconds)")
-    .option(
-      "--log-attr <key=value>",
-      "Log attribute filter (repeatable)",
-      collect,
-      []
-    )
-    .option(
-      "--resource-attr <key=value>",
-      "Resource attribute filter (repeatable)",
-      collect,
-      []
-    )
-    .option(
-      "--scope-attr <key=value>",
-      "Scope attribute filter (repeatable)",
-      collect,
-      []
-    )
-    .option("--sort <order>", "Sort order (ASC|DESC)")
-    .option("--timeout <ms>", "Request timeout")
-    .option("-c, --config <path>", "Config file path")
-    .option("--url <url>", "API base URL")
-    .option("--token <token>", "Auth token")
-    .action(async (opts: LogsSearchOptions) => {
-      const format = detectFormat(opts.json, opts.table);
-      const fields = parseFields(opts.fields);
-      try {
-        const client = createClient(opts);
-        const limit = opts.limit ? parseInt(opts.limit, 10) : undefined;
+  withConnectionOptions(
+    logs
+      .command("search")
+      .description("Search logs")
+      .option("-j, --json", "JSON output")
+      .option("-t, --table", "Table output")
+      .option("-f, --fields <fields>", "Comma-separated fields to include")
+      .option("-l, --limit <n>", "Max results")
+      .option("--trace-id <id>", "Filter by trace ID")
+      .option("--span-id <id>", "Filter by span ID")
+      .option("-s, --service <name>", "Filter by service name")
+      .option("--scope <name>", "Filter by scope name")
+      .option("--severity-text <level>", "Filter by severity text")
+      .option("--severity-min <n>", "Min severity number")
+      .option("--severity-max <n>", "Max severity number")
+      .option("-b, --body <text>", "Filter by body contains")
+      .option("--timestamp-min <ns>", "Min timestamp (nanoseconds)")
+      .option("--timestamp-max <ns>", "Max timestamp (nanoseconds)")
+      .option(
+        "--log-attr <key=value>",
+        "Log attribute filter (repeatable)",
+        collect,
+        []
+      )
+      .option(
+        "--resource-attr <key=value>",
+        "Resource attribute filter (repeatable)",
+        collect,
+        []
+      )
+      .option(
+        "--scope-attr <key=value>",
+        "Scope attribute filter (repeatable)",
+        collect,
+        []
+      )
+      .option("--sort <order>", "Sort order (ASC|DESC)")
+  ).action(async (opts: LogsSearchOptions) => {
+    const format = detectFormat(opts.json, opts.table);
+    const fields = parseFields(opts.fields);
+    try {
+      const client = createClient(opts);
+      const limit = opts.limit ? parseInt(opts.limit, 10) : undefined;
 
-        const filter = {
-          traceId: opts.traceId,
-          spanId: opts.spanId,
-          serviceName: opts.service,
-          scopeName: opts.scope,
-          severityText: opts.severityText,
-          severityNumberMin: opts.severityMin
-            ? parseInt(opts.severityMin, 10)
-            : undefined,
-          severityNumberMax: opts.severityMax
-            ? parseInt(opts.severityMax, 10)
-            : undefined,
-          bodyContains: opts.body,
-          timestampMin: opts.timestampMin,
-          timestampMax: opts.timestampMax,
-          logAttributes: parseAttributes(opts.logAttr),
-          resourceAttributes: parseAttributes(opts.resourceAttr),
-          scopeAttributes: parseAttributes(opts.scopeAttr),
-          limit,
-          sortOrder: opts.sort as "ASC" | "DESC" | undefined,
-        };
+      const filter = {
+        traceId: opts.traceId,
+        spanId: opts.spanId,
+        serviceName: opts.service,
+        scopeName: opts.scope,
+        severityText: opts.severityText,
+        severityNumberMin: opts.severityMin
+          ? parseInt(opts.severityMin, 10)
+          : undefined,
+        severityNumberMax: opts.severityMax
+          ? parseInt(opts.severityMax, 10)
+          : undefined,
+        bodyContains: opts.body,
+        timestampMin: opts.timestampMin,
+        timestampMax: opts.timestampMax,
+        logAttributes: parseAttributes(opts.logAttr),
+        resourceAttributes: parseAttributes(opts.resourceAttr),
+        scopeAttributes: parseAttributes(opts.scopeAttr),
+        limit,
+        sortOrder: opts.sort as "ASC" | "DESC" | undefined,
+      };
 
-        const result = await client.searchLogsPage(filter);
-        output(result.data, { format, fields });
-      } catch (err) {
-        outputError(err, format === "json");
-        process.exit(1);
-      }
-    });
+      const result = await client.searchLogsPage(filter);
+      output(result.data, { format, fields });
+    } catch (err) {
+      outputError(err, format === "json");
+      process.exit(1);
+    }
+  });
 
   return logs;
 }

--- a/packages/cli/src/commands/traces.ts
+++ b/packages/cli/src/commands/traces.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import {
   createClient,
   parseAttributes,
+  withConnectionOptions,
   type ClientOptions,
 } from "../client.js";
 import { detectFormat, output, outputError, parseFields } from "../output.js";
@@ -37,99 +38,93 @@ interface TracesSearchOptions extends ClientOptions {
 export function createTracesCommand(): Command {
   const traces = new Command("traces").description("Query traces");
 
-  traces
-    .command("get")
-    .description("Get all spans for a trace by ID")
-    .argument("<traceId>", "Trace ID")
-    .option("-j, --json", "JSON output")
-    .option("-t, --table", "Table output")
-    .option("-f, --fields <fields>", "Comma-separated fields to include")
-    .option("--timeout <ms>", "Request timeout")
-    .option("-c, --config <path>", "Config file path")
-    .option("--url <url>", "API base URL")
-    .option("--token <token>", "Auth token")
-    .action(async (traceId: string, opts: TracesGetOptions) => {
-      const format = detectFormat(opts.json, opts.table);
-      const fields = parseFields(opts.fields);
-      try {
-        const client = createClient(opts);
-        const spans = await client.getTrace(traceId);
-        output(spans, { format, fields });
-      } catch (err) {
-        outputError(err, format === "json");
-        process.exit(1);
-      }
-    });
+  withConnectionOptions(
+    traces
+      .command("get")
+      .description("Get all spans for a trace by ID")
+      .argument("<traceId>", "Trace ID")
+      .option("-j, --json", "JSON output")
+      .option("-t, --table", "Table output")
+      .option("-f, --fields <fields>", "Comma-separated fields to include")
+  ).action(async (traceId: string, opts: TracesGetOptions) => {
+    const format = detectFormat(opts.json, opts.table);
+    const fields = parseFields(opts.fields);
+    try {
+      const client = createClient(opts);
+      const spans = await client.getTrace(traceId);
+      output(spans, { format, fields });
+    } catch (err) {
+      outputError(err, format === "json");
+      process.exit(1);
+    }
+  });
 
-  traces
-    .command("search")
-    .description("Search traces")
-    .option("-j, --json", "JSON output")
-    .option("-t, --table", "Table output")
-    .option("-f, --fields <fields>", "Comma-separated fields to include")
-    .option("-l, --limit <n>", "Max results")
-    .option("--trace-id <id>", "Filter by trace ID")
-    .option("--span-id <id>", "Filter by span ID")
-    .option("--parent-span-id <id>", "Filter by parent span ID")
-    .option("-s, --service <name>", "Filter by service name")
-    .option("--span-name <name>", "Filter by span name")
-    .option("--span-kind <kind>", "Filter by span kind")
-    .option("--status-code <code>", "Filter by status code")
-    .option("--scope <name>", "Filter by scope name")
-    .option("--timestamp-min <ns>", "Min timestamp (nanoseconds)")
-    .option("--timestamp-max <ns>", "Max timestamp (nanoseconds)")
-    .option("--duration-min <ns>", "Min duration (nanoseconds)")
-    .option("--duration-max <ns>", "Max duration (nanoseconds)")
-    .option(
-      "--span-attr <key=value>",
-      "Span attribute filter (repeatable)",
-      collect,
-      []
-    )
-    .option(
-      "--resource-attr <key=value>",
-      "Resource attribute filter (repeatable)",
-      collect,
-      []
-    )
-    .option("--sort <order>", "Sort order (ASC|DESC)")
-    .option("--timeout <ms>", "Request timeout")
-    .option("-c, --config <path>", "Config file path")
-    .option("--url <url>", "API base URL")
-    .option("--token <token>", "Auth token")
-    .action(async (opts: TracesSearchOptions) => {
-      const format = detectFormat(opts.json, opts.table);
-      const fields = parseFields(opts.fields);
-      try {
-        const client = createClient(opts);
-        const limit = opts.limit ? parseInt(opts.limit, 10) : undefined;
+  withConnectionOptions(
+    traces
+      .command("search")
+      .description("Search traces")
+      .option("-j, --json", "JSON output")
+      .option("-t, --table", "Table output")
+      .option("-f, --fields <fields>", "Comma-separated fields to include")
+      .option("-l, --limit <n>", "Max results")
+      .option("--trace-id <id>", "Filter by trace ID")
+      .option("--span-id <id>", "Filter by span ID")
+      .option("--parent-span-id <id>", "Filter by parent span ID")
+      .option("-s, --service <name>", "Filter by service name")
+      .option("--span-name <name>", "Filter by span name")
+      .option("--span-kind <kind>", "Filter by span kind")
+      .option("--status-code <code>", "Filter by status code")
+      .option("--scope <name>", "Filter by scope name")
+      .option("--timestamp-min <ns>", "Min timestamp (nanoseconds)")
+      .option("--timestamp-max <ns>", "Max timestamp (nanoseconds)")
+      .option("--duration-min <ns>", "Min duration (nanoseconds)")
+      .option("--duration-max <ns>", "Max duration (nanoseconds)")
+      .option(
+        "--span-attr <key=value>",
+        "Span attribute filter (repeatable)",
+        collect,
+        []
+      )
+      .option(
+        "--resource-attr <key=value>",
+        "Resource attribute filter (repeatable)",
+        collect,
+        []
+      )
+      .option("--sort <order>", "Sort order (ASC|DESC)")
+  ).action(async (opts: TracesSearchOptions) => {
+    const format = detectFormat(opts.json, opts.table);
+    const fields = parseFields(opts.fields);
+    try {
+      const client = createClient(opts);
+      const limit = opts.limit ? parseInt(opts.limit, 10) : undefined;
 
-        const filter = {
-          traceId: opts.traceId,
-          spanId: opts.spanId,
-          parentSpanId: opts.parentSpanId,
-          serviceName: opts.service,
-          spanName: opts.spanName,
-          spanKind: opts.spanKind,
-          statusCode: opts.statusCode,
-          scopeName: opts.scope,
-          timestampMin: opts.timestampMin,
-          timestampMax: opts.timestampMax,
-          durationMin: opts.durationMin,
-          durationMax: opts.durationMax,
-          spanAttributes: parseAttributes(opts.spanAttr),
-          resourceAttributes: parseAttributes(opts.resourceAttr),
-          limit,
-          sortOrder: opts.sort as "ASC" | "DESC" | undefined,
-        };
+      const filter = {
+        traceId: opts.traceId,
+        spanId: opts.spanId,
+        parentSpanId: opts.parentSpanId,
+        serviceName: opts.service,
+        spanName: opts.spanName,
+        spanKind: opts.spanKind,
+        statusCode: opts.statusCode,
+        scopeName: opts.scope,
+        timestampMin: opts.timestampMin,
+        timestampMax: opts.timestampMax,
+        durationMin: opts.durationMin,
+        durationMax: opts.durationMax,
+        spanAttributes: parseAttributes(opts.spanAttr),
+        resourceAttributes: parseAttributes(opts.resourceAttr),
+        limit,
+        sortOrder: opts.sort as "ASC" | "DESC" | undefined,
+      };
 
-        const result = await client.searchTracesPage(filter);
-        output(result.data, { format, fields });
-      } catch (err) {
-        outputError(err, format === "json");
-        process.exit(1);
-      }
-    });
+      const result = await client.searchTracesPage(filter);
+      output(result.data, { format, fields });
+    } catch (err) {
+      outputError(err, format === "json");
+      process.exit(1);
+    }
+  });
 
   return traces;
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -14,6 +14,14 @@ program
   .version(pkg.version)
   .addCommand(createTracesCommand())
   .addCommand(createLogsCommand())
-  .addCommand(createMetricsCommand());
+  .addCommand(createMetricsCommand())
+  .addHelpText(
+    "after",
+    `
+Examples:
+  $ kopai traces search                                          # localhost:8000 (default, for @kopai/app running locally)
+  $ kopai traces search --url https://example.com/signals        # remote instance
+  $ kopai logs search --url https://example.com/signals --token kpi_…  # with auth`
+  );
 
 program.parse();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * CLI help now includes enhanced examples for traces and logs.

* **New Features**
  * Connection-related options (--url, --token, --config, --timeout) are now consistently available across logs, metrics, and traces commands.

* **Refactor**
  * Command wiring for logs, metrics, and traces streamlined to centralize connection option handling and reduce redundancy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->