### PR TITLE
feat: publish skills with tessl

### DIFF
--- a/.github/workflows/publish-skills.yml
+++ b/.github/workflows/publish-skills.yml
@@ -10,33 +10,23 @@ on:
     paths:
       - "skills/**"
 
+concurrency:
+  group: publish-skills-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  publish-create-dashboard:
+  publish-skill:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        skill:
+          - create-dashboard
+          - otel-instrumentation
+          - root-cause-analysis
     steps:
       - uses: actions/checkout@v6
       - uses: tesslio/publish@main
         with:
           token: ${{ secrets.TESSL_API_TOKEN }}
-          path: "./skills/create-dashboard"
-          review-threshold: "50"
-
-  publish-otel-instrumentation:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: tesslio/publish@main
-        with:
-          token: ${{ secrets.TESSL_API_TOKEN }}
-          path: "./skills/otel-instrumentation"
-          review-threshold: "50"
-
-  publish-root-cause-analysis:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: tesslio/publish@main
-        with:
-          token: ${{ secrets.TESSL_API_TOKEN }}
-          path: "./skills/root-cause-analysis"
+          path: "./skills/${{ matrix.skill }}"
           review-threshold: "50"

--- a/.github/workflows/publish-skills.yml
+++ b/.github/workflows/publish-skills.yml
@@ -1,0 +1,42 @@
+name: Publish Skills to Tessl
+
+permissions:
+  id-token: write
+  contents: read
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "skills/**"
+
+jobs:
+  publish-create-dashboard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: tesslio/publish@main
+        with:
+          token: ${{ secrets.TESSL_API_TOKEN }}
+          path: "./skills/create-dashboard"
+          review-threshold: "50"
+
+  publish-otel-instrumentation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: tesslio/publish@main
+        with:
+          token: ${{ secrets.TESSL_API_TOKEN }}
+          path: "./skills/otel-instrumentation"
+          review-threshold: "50"
+
+  publish-root-cause-analysis:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: tesslio/publish@main
+        with:
+          token: ${{ secrets.TESSL_API_TOKEN }}
+          path: "./skills/root-cause-analysis"
+          review-threshold: "50"

--- a/skills/create-dashboard/tile.json
+++ b/skills/create-dashboard/tile.json
@@ -1,0 +1,8 @@
+{
+  "name": "kopai/create-dashboard",
+  "version": "1.0.0",
+  "private": false,
+  "skills": {
+    "create-dashboard": "./SKILL.md"
+  }
+}

--- a/skills/otel-instrumentation/tile.json
+++ b/skills/otel-instrumentation/tile.json
@@ -1,0 +1,8 @@
+{
+  "name": "kopai/otel-instrumentation",
+  "version": "1.0.0",
+  "private": false,
+  "skills": {
+    "otel-instrumentation": "./SKILL.md"
+  }
+}

--- a/skills/root-cause-analysis/tile.json
+++ b/skills/root-cause-analysis/tile.json
@@ -1,0 +1,8 @@
+{
+  "name": "kopai/root-cause-analysis",
+  "version": "1.0.0",
+  "private": false,
+  "skills": {
+    "root-cause-analysis": "./SKILL.md"
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Released three new public skills: create-dashboard (v1.0.0), otel-instrumentation (v1.0.0), and root-cause-analysis (v1.0.0).

* **Chores**
  * Added an automated publishing workflow to push skills to Tessl on main branch changes, with per-skill publishing jobs and concurrency control plus configurable review thresholds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->