### PR TITLE
fix(cli): default to hosted kopai API url

### DIFF
--- a/.changeset/large-colts-unite.md
+++ b/.changeset/large-colts-unite.md
@@ -1,0 +1,5 @@
+---
+"@kopai/cli": patch
+---
+
+Defaulted the CLI API URL to the hosted Kopai endpoint (https://api.kopai.app/v2) so `kopai login` and query commands work against kopai.app without `--url`.

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -12,11 +12,11 @@ npx @kopai/cli <command>
 
 ## Configuration
 
-**Default:** `http://localhost:8000` (no auth required)
+**Default:** `https://api.kopai.app/v2` (hosted Kopai instance, requires auth)
 
-Works out of the box with local @kopai/app. No configuration needed for local development.
+Run `kopai login` to save a token, or pass `--token` on each call. For local development against `@kopai/app`, override with `--url http://localhost:8000` (no auth required).
 
-For remote/authenticated APIs, create `.kopairc` in current or home directory:
+To persist configuration, create `.kopairc` in current or home directory:
 
 ```json
 {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -35,7 +35,7 @@ kopai logs search --service my-api --limit 20
 kopai metrics discover
 ```
 
-By default connects to `https://api.kopai.app/v2`. For local development against `@kopai/app`, pass `--url http://localhost:8000` or save it to `.kopairc`.
+By default connects to `https://api.kopai.app/v2`, which requires authentication — run `kopai login` to save a token to `.kopairc` (or pass `--token` on each call) before querying. For local development against `@kopai/app`, override with `--url http://localhost:8000` or save it to `.kopairc`.
 
 ## Configuration
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -35,7 +35,7 @@ kopai logs search --service my-api --limit 20
 kopai metrics discover
 ```
 
-By default connects to `http://localhost:8000`.
+By default connects to `https://api.kopai.app/v2`. For local development against `@kopai/app`, pass `--url http://localhost:8000` or save it to `.kopairc`.
 
 ## Configuration
 

--- a/packages/cli/src/client.ts
+++ b/packages/cli/src/client.ts
@@ -1,6 +1,6 @@
 import type { Command } from "commander";
 import { KopaiClient } from "@kopai/sdk";
-import { loadConfig } from "./config.js";
+import { loadConfig, DEFAULT_URL } from "./config.js";
 
 export function withConnectionOptions<T extends Command>(cmd: T): T {
   return cmd
@@ -16,8 +16,6 @@ export interface ClientOptions {
   token?: string;
   timeout?: number;
 }
-
-const DEFAULT_URL = "http://localhost:8000";
 
 export interface ConnectionOpts {
   url: string;

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -9,7 +9,7 @@ export interface Config {
 
 export const CONFIG_FILENAME = ".kopairc";
 export const TOKEN_PREFIX_LENGTH = 10;
-export const DEFAULT_URL = "http://localhost:8000";
+export const DEFAULT_URL = "https://api.kopai.app/v2";
 
 /** Owner read+write only (rw-------). Used for files containing secrets. */
 const OWNER_READ_WRITE = 0o600;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -29,9 +29,12 @@ program
     "after",
     `
 Examples:
-  $ kopai traces search                                          # ${DEFAULT_URL} (default)
-  $ kopai traces search --url http://localhost:8000              # local @kopai/app
-  $ kopai logs search --url https://example.com --token kpi_…    # custom instance`
+  $ kopai login                                                  # save a token for the hosted default (requires auth)
+  $ kopai traces search                                          # ${DEFAULT_URL} (default, requires auth)
+  $ kopai traces search --url http://localhost:8000              # local @kopai/app, no auth
+  $ kopai logs search --url https://example.com --token kpi_…    # custom instance
+
+Run "kopai login" once to authenticate against ${DEFAULT_URL}, or pass --url http://localhost:8000 to target a local @kopai/app.`
   );
 
 program.parse();

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -9,6 +9,7 @@ import { createLoginCommand } from "./commands/login.js";
 import { createLogoutCommand } from "./commands/logout.js";
 import { createWhoamiCommand } from "./commands/whoami.js";
 import { checkForUpdates } from "./update-check.js";
+import { DEFAULT_URL } from "./config.js";
 import pkg from "../package.json" with { type: "json" };
 
 const program = new Command();
@@ -28,9 +29,9 @@ program
     "after",
     `
 Examples:
-  $ kopai traces search                                          # localhost:8000 (default, for @kopai/app running locally)
-  $ kopai traces search --url https://example.com                # remote instance
-  $ kopai logs search --url https://example.com --token kpi_…    # with auth`
+  $ kopai traces search                                          # ${DEFAULT_URL} (default)
+  $ kopai traces search --url http://localhost:8000              # local @kopai/app
+  $ kopai logs search --url https://example.com --token kpi_…    # custom instance`
   );
 
 program.parse();


### PR DESCRIPTION
When running `kopai login` without `--url`, the generated `.kopairc` was written with `"url": "http://localhost:8000"`, which meant users targeting the hosted instance had to re-run with `--url https://api.kopai.app/v2` to actually log in.

This PR flips the CLI's `DEFAULT_URL` so `kopai login` produces a working `.kopairc` for kopai.app out of the box. Local `@kopai/app` development still works — just pass `--url http://localhost:8000` (or save it to `.kopairc`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Default CLI API endpoint now points to the hosted authenticated service.
  * Instructions added to authenticate via `kopai login` or supply `--token` per call.
  * Help text and examples updated to show authenticated defaults and explicit local usage.
  * Guidance retained for local development via `--url http://localhost:8000`.
* **Chores**
  * Release metadata added to mark this behavioral update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->