### PR TITLE
fix(cli): default kopai url

### DIFF
--- a/.changeset/orange-ghosts-repair.md
+++ b/.changeset/orange-ghosts-repair.md
@@ -1,0 +1,5 @@
+---
+"@kopai/cli": minor
+---
+
+Fix default kopai/cli url

--- a/packages/cli/src/client.test.ts
+++ b/packages/cli/src/client.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+
+vi.mock("node:fs");
+vi.mock("node:os");
+
+import { resolveConnectionOpts } from "./client.js";
+
+describe("resolveConnectionOpts default URL", () => {
+  beforeEach(() => {
+    vi.mocked(os.homedir).mockReturnValue("/home/user");
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("defaults to localhost:8000 when no config or --url", () => {
+    const { url } = resolveConnectionOpts({});
+    expect(url).toBe("http://localhost:8000");
+  });
+
+  it("uses --url when provided, ignoring default", () => {
+    const { url } = resolveConnectionOpts({ url: "https://api.kopai.app/v2" });
+    expect(url).toBe("https://api.kopai.app/v2");
+  });
+
+  it("uses url from config file when no --url", () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue(
+      JSON.stringify({ url: "https://custom.example.com" })
+    );
+
+    const { url } = resolveConnectionOpts({});
+    expect(url).toBe("https://custom.example.com");
+  });
+});

--- a/packages/cli/src/commands/login.test.ts
+++ b/packages/cli/src/commands/login.test.ts
@@ -24,7 +24,7 @@ vi.mock("node:readline", () => ({
   }),
 }));
 
-import { saveConfig, resolveConfigPath, DEFAULT_URL } from "../config.js";
+import { saveConfig, resolveConfigPath } from "../config.js";
 import { existsSync, readFileSync } from "node:fs";
 import { createLoginCommand } from "./login.js";
 
@@ -60,11 +60,14 @@ describe("login command", () => {
     vi.restoreAllMocks();
   });
 
-  it("calls saveConfig with token and default url", async () => {
+  it("calls saveConfig with token and hosted prod url by default", async () => {
     await runCommand([]);
 
     expect(saveConfig).toHaveBeenCalledWith(
-      { token: "kpi_test_token_12345678901234567890123456", url: DEFAULT_URL },
+      {
+        token: "kpi_test_token_12345678901234567890123456",
+        url: "https://api.kopai.app/v2",
+      },
       "/mock/.kopairc"
     );
   });
@@ -88,7 +91,10 @@ describe("login command", () => {
 
     expect(resolveConfigPath).toHaveBeenCalledWith(true);
     expect(saveConfig).toHaveBeenCalledWith(
-      { token: "kpi_test_token_12345678901234567890123456", url: DEFAULT_URL },
+      {
+        token: "kpi_test_token_12345678901234567890123456",
+        url: "https://api.kopai.app/v2",
+      },
       "/home/user/.kopairc"
     );
   });

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -6,9 +6,10 @@ import {
   saveConfig,
   resolveConfigPath,
   TOKEN_PREFIX_LENGTH,
-  DEFAULT_URL,
   type Config,
 } from "../config.js";
+
+const LOGIN_DEFAULT_URL = "https://api.kopai.app/v2";
 
 function readTokenFromStdin(): Promise<string> {
   return new Promise((resolve) => {
@@ -38,7 +39,7 @@ export function createLoginCommand(): Command {
 
       const updates: Partial<Config> = {
         token,
-        url: opts.url ?? DEFAULT_URL,
+        url: opts.url ?? LOGIN_DEFAULT_URL,
       };
 
       const targetPath = resolveConfigPath(opts.global ?? false);

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -9,7 +9,7 @@ export interface Config {
 
 export const CONFIG_FILENAME = ".kopairc";
 export const TOKEN_PREFIX_LENGTH = 10;
-export const DEFAULT_URL = "https://api.kopai.app/v2";
+export const DEFAULT_URL = "http://localhost:8000";
 
 /** Owner read+write only (rw-------). Used for files containing secrets. */
 const OWNER_READ_WRITE = 0o600;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -9,7 +9,6 @@ import { createLoginCommand } from "./commands/login.js";
 import { createLogoutCommand } from "./commands/logout.js";
 import { createWhoamiCommand } from "./commands/whoami.js";
 import { checkForUpdates } from "./update-check.js";
-import { DEFAULT_URL } from "./config.js";
 import pkg from "../package.json" with { type: "json" };
 
 const program = new Command();
@@ -29,12 +28,10 @@ program
     "after",
     `
 Examples:
-  $ kopai login                                                  # save a token for the hosted default (requires auth)
-  $ kopai traces search                                          # ${DEFAULT_URL} (default, requires auth)
-  $ kopai traces search --url http://localhost:8000              # local @kopai/app, no auth
-  $ kopai logs search --url https://example.com --token kpi_…    # custom instance
-
-Run "kopai login" once to authenticate against ${DEFAULT_URL}, or pass --url http://localhost:8000 to target a local @kopai/app.`
+  $ kopai traces search                                          # http://localhost:8000 (default, for @kopai/app running locally)
+  $ kopai traces search --url https://api.kopai.app/v2          # hosted instance (run "kopai login" first)
+  $ kopai login                                                  # save token for https://api.kopai.app/v2
+  $ kopai logs search --url https://example.com --token kpi_…    # custom instance with auth`
   );
 
 program.parse();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed default URL resolution to properly handle both local development and hosted environments
  * Updated help documentation with explicit URL examples

* **Tests**
  * Added comprehensive test coverage for URL configuration and resolution behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->