### PR TITLE
feat(ui): add AggregateTable renderer with unit-aware cells and humanised headers

### DIFF
--- a/.changeset/aggregate-table-renderer.md
+++ b/.changeset/aggregate-table-renderer.md
@@ -3,6 +3,24 @@
 "@kopai/ui": minor
 ---
 
-Add an `AggregateTable` dashboard component that renders aggregate-mode `query` results (dimension + measure columns) as a table.
+Add an `AggregateTable` dashboard component that renders aggregate-mode `query` results (dimension + measure columns) as a table, with unit-aware cells and humanised headers.
 
 Previously every data-bound SDUI renderer validated for raw signal rows, so an aggregate query (e.g. top spans by `AVG(Duration)`, request counts grouped by `StatusCode`) had no renderer and, if bound to `MetricTable`, failed at render with "This panel displays raw metric rows…". `AggregateTable` accepts the polymorphic aggregate result and derives its columns from the rows, so any signal's aggregate output can be displayed.
+
+Because the columns come from the query rather than a fixed schema, the component carries no unit or naming metadata of its own. Two further props supply it, alongside the existing `maxRows`. Following the rest of the catalog, both are nullable but must be present — pass `null` when unused.
+
+**`units`** maps a column name to its OTel unit, so the cell renders in human terms:
+
+```ts
+props: {
+  maxRows: 10,
+  units: { avg_duration_ns: "ns", error_rate: "1" },
+  labels: null,
+}
+```
+
+This matters most for durations. OTel stores span `Duration` in nanoseconds, so an unannotated `AVG(Duration)` of `23070000` renders as `23.07M` — digits that coincidentally match the millisecond value, which is what makes the bare SI suffix misleading. Annotated, the same cell reads `23.07 ms`. Units resolve through the same scale resolver the charts and `MetricStat` already use, so `ns`/`us`/`ms`/`s` render as durations, `By` as bytes, `"1"` as a percentage, and an unknown unit as a scaled number with the unit appended (`{spans}` → `2.50 M spans`). Unannotated columns keep plain K/M/G scaling.
+
+**`labels`** overrides the header for any column. Headers are otherwise derived automatically: snake_case, dotted and PascalCase names become Title Case (`span_count` → "Span Count", `service.name` → "Service Name", `SpanName` → "Span Name"), acronym runs stay whole (`HTTPRoute` → "HTTP Route"), and a trailing unit token is dropped when the column is unit-annotated (`avg_duration_ns` + `ns` → "Avg Duration") since the unit already appears in the cell. The drop only fires when name and annotation agree — `avg_duration_ms` annotated `ns` keeps its suffix rather than being relabelled to something the values contradict. Humanising flattens dotted OTel attribute names (`SpanAttributes.http.route` → "Span Attributes Http Route"), which is the case `labels` exists to fix.
+
+Separately, nanoseconds gained a scale family in the shared unit resolver. Any metric whose OTel unit is `ns` previously fell through to generic scaling and rendered as `23.1 M ns`; it now renders as `23.1 ms`. This affects `MetricStat`, `MetricTimeSeries`, and `MetricHistogram` as well as the new table. No other unit changes behaviour.

--- a/.changeset/aggregate-table-renderer.md
+++ b/.changeset/aggregate-table-renderer.md
@@ -1,0 +1,8 @@
+---
+"@kopai/ui-core": minor
+"@kopai/ui": minor
+---
+
+Add an `AggregateTable` dashboard component that renders aggregate-mode `query` results (dimension + measure columns) as a table.
+
+Previously every data-bound SDUI renderer validated for raw signal rows, so an aggregate query (e.g. top spans by `AVG(Duration)`, request counts grouped by `StatusCode`) had no renderer and, if bound to `MetricTable`, failed at render with "This panel displays raw metric rows…". `AggregateTable` accepts the polymorphic aggregate result and derives its columns from the rows, so any signal's aggregate output can be displayed.

--- a/examples/ui-react-app/src/custom-observability-catalog.tsx
+++ b/examples/ui-react-app/src/custom-observability-catalog.tsx
@@ -14,7 +14,8 @@
  *   2. <RequestState> / <NoSource> helpers used by every data-backed renderer
  *   3. Primitive renderers:   Stack, Grid, Card, Heading, Text, Badge, Divider, Empty
  *   4. Data-backed renderers: MetricStat, MetricTimeSeries, MetricHistogram,
- *                             MetricTable, MetricDiscovery, LogTimeline, TraceDetail
+ *                             MetricTable, AggregateTable, MetricDiscovery,
+ *                             LogTimeline, TraceDetail
  *   5. Kitchen-sink `UITree` exercising every component
  *   6. Provider-wrapped <ExampleObservabilityCatalog /> export
  */
@@ -24,6 +25,7 @@
 // =============================================================================
 import {
   KopaiClient,
+  kq,
   type AggregatedMetricRow,
   type OtelLogsRow,
   type OtelMetricsRow,
@@ -728,6 +730,21 @@ const ObservabilityRenderer = createRendererFromCatalog(observabilityCatalog, {
 // =============================================================================
 // 5. Kitchen-sink UITree — exercises every component in one layout.
 // =============================================================================
+
+// The other tiles below use the legacy per-signal methods, which only ever
+// return raw rows. AggregateTable is the one component bound exclusively to the
+// polymorphic `query` method, so its tile needs a real aggregate-mode query —
+// built with `kq` so the dimension/measure columns are checked at compile time
+// rather than hand-written as a KopaiQuery literal.
+const topSpansByCalls = kq.traces
+  .aggregate()
+  .dimension("SpanName")
+  .measure((m) => m.count("calls"))
+  .measure((m) => m.avg("Duration", "avg_duration"))
+  .timeRelative("1h")
+  .summary()
+  .build();
+
 const kitchenSinkTree = {
   root: "root",
   elements: {
@@ -843,6 +860,7 @@ const kitchenSinkTree = {
         "c-timeseries",
         "c-histogram",
         "c-table",
+        "c-aggregate",
         "c-discovery",
         "c-logs",
         "c-traces",
@@ -976,6 +994,32 @@ const kitchenSinkTree = {
         params: { metricType: "Sum" as const, limit: 10 },
       },
       props: { maxRows: 5 },
+    },
+
+    "c-aggregate": {
+      key: "c-aggregate",
+      type: "Card" as const,
+      parentKey: "grid",
+      children: ["aggtable"],
+      props: {
+        title: "AggregateTable",
+        description: "query (aggregate mode)",
+        padding: null,
+      },
+    },
+    aggtable: {
+      key: "aggtable",
+      type: "AggregateTable" as const,
+      parentKey: "c-aggregate",
+      children: [],
+      dataSource: {
+        method: "query" as const,
+        params: topSpansByCalls,
+      },
+      // Duration is stored in nanoseconds; without the unit the cell reads
+      // "23.07M" rather than "23.07 ms". Headers humanise on their own, so
+      // `labels` stays null here.
+      props: { maxRows: 5, units: { avg_duration: "ns" }, labels: null },
     },
 
     "c-discovery": {

--- a/examples/ui-react-app/src/custom-observability-catalog.tsx
+++ b/examples/ui-react-app/src/custom-observability-catalog.tsx
@@ -484,8 +484,13 @@ function hasAggregateRowShape(
   // A scalar-only object can still be a raw signal row (e.g. a metric row with
   // no attributes); defer to the raw-row guards first so a raw result bound
   // here surfaces the shape error instead of rendering silently. Matches
-  // production `hasAggregateRowShape` in @kopai/ui's narrowRows.ts.
-  if (hasMetricRowShape(v) || hasLogRowShape(v) || hasTraceRowShape(v)) {
+  // production `hasAggregateRowShape` in @kopai/ui's narrowRows.ts — including
+  // the companion-key check, without which a metrics aggregate grouping by
+  // TimeUnix would be misread as a raw metric row.
+  const looksRawMetric =
+    hasMetricRowShape(v) &&
+    ["Value", "MetricName", "MetricType", "StartTimeUnix"].some((k) => k in v);
+  if (looksRawMetric || hasLogRowShape(v) || hasTraceRowShape(v)) {
     return false;
   }
   return Object.values(v).every(

--- a/examples/ui-react-app/src/custom-observability-catalog.tsx
+++ b/examples/ui-react-app/src/custom-observability-catalog.tsx
@@ -470,6 +470,67 @@ function MetricTable(props: RendererProps<"MetricTable">) {
   );
 }
 
+// ---------- AggregateTable --------------------------------------------------
+// The mirror image of the raw renderers: an aggregate `query` returns dynamic
+// dimension/measure rows (KopaiAggregateRow — a flat scalar record), so the
+// columns come from the rows themselves. Raw rows carry object-valued fields,
+// so "every value is scalar" separates an aggregate result from a raw one.
+function hasAggregateRowShape(
+  v: unknown
+): v is Record<string, string | number | null> {
+  if (!isRecord(v)) return false;
+  return Object.values(v).every(
+    (val) => val === null || typeof val === "string" || typeof val === "number"
+  );
+}
+
+function AggregateTable(props: RendererProps<"AggregateTable">) {
+  if (!props.hasData) return <NoSource name="AggregateTable" />;
+  const maxRows = props.element.props.maxRows ?? 10;
+  const rows = narrowRows(props.response, hasAggregateRowShape);
+  if (rows === null) {
+    return (
+      <RequestState loading={props.loading} error={props.error}>
+        <UnsupportedShape name="AggregateTable" />
+      </RequestState>
+    );
+  }
+  const columns = [...new Set(rows.flatMap((r) => Object.keys(r)))];
+  const shown = rows.slice(0, maxRows);
+  return (
+    <RequestState loading={props.loading} error={props.error}>
+      {shown.length === 0 ? (
+        <div style={{ fontSize: 12, color: "#999" }}>(no rows)</div>
+      ) : (
+        <table
+          style={{ width: "100%", fontSize: 12, borderCollapse: "collapse" }}
+        >
+          <thead>
+            <tr style={{ textAlign: "left", color: "#666" }}>
+              {columns.map((c) => (
+                <th key={c} style={{ padding: "4px 8px" }}>
+                  {c}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {shown.map((r, i) => (
+              <tr key={i} style={{ borderTop: "1px solid #eee" }}>
+                {columns.map((c) => (
+                  <td key={c} style={{ padding: "4px 8px" }}>
+                    {String(r[c] ?? "—")}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </RequestState>
+  );
+}
+
 // ---------- MetricDiscovery -------------------------------------------------
 // Unlike the paginated endpoints, `discoverMetrics` returns `{ metrics: [...] }`
 // — the shape is different, and the renderer reads `response.metrics` (not
@@ -633,7 +694,7 @@ function TraceDetail(props: TraceDetailProps) {
 }
 
 // =============================================================================
-// Register all 15 renderers with the catalog. `createRendererFromCatalog`
+// Register all 16 renderers with the catalog. `createRendererFromCatalog`
 // enforces at compile time that the registry matches the catalog shape.
 // =============================================================================
 const ObservabilityRenderer = createRendererFromCatalog(observabilityCatalog, {
@@ -651,6 +712,7 @@ const ObservabilityRenderer = createRendererFromCatalog(observabilityCatalog, {
   MetricTimeSeries,
   MetricHistogram,
   MetricTable,
+  AggregateTable,
   MetricDiscovery,
   LogTimeline,
   TraceDetail,

--- a/examples/ui-react-app/src/custom-observability-catalog.tsx
+++ b/examples/ui-react-app/src/custom-observability-catalog.tsx
@@ -479,6 +479,13 @@ function hasAggregateRowShape(
   v: unknown
 ): v is Record<string, string | number | null> {
   if (!isRecord(v)) return false;
+  // A scalar-only object can still be a raw signal row (e.g. a metric row with
+  // no attributes); defer to the raw-row guards first so a raw result bound
+  // here surfaces the shape error instead of rendering silently. Matches
+  // production `hasAggregateRowShape` in @kopai/ui's narrowRows.ts.
+  if (hasMetricRowShape(v) || hasLogRowShape(v) || hasTraceRowShape(v)) {
+    return false;
+  }
   return Object.values(v).every(
     (val) => val === null || typeof val === "string" || typeof val === "number"
   );

--- a/packages/ui-core/src/lib/observability-catalog.ts
+++ b/packages/ui-core/src/lib/observability-catalog.ts
@@ -154,7 +154,7 @@ export const observabilityCatalog = createCatalog({
     },
 
     AggregateTable: {
-      props: z.object({ maxRows: z.number().nullable() }),
+      props: z.object({ maxRows: z.number().int().positive().nullable() }),
       hasChildren: false,
       description:
         "Tabular display of aggregate query results — dimension and measure " +

--- a/packages/ui-core/src/lib/observability-catalog.ts
+++ b/packages/ui-core/src/lib/observability-catalog.ts
@@ -153,6 +153,17 @@ export const observabilityCatalog = createCatalog({
       acceptsDataFrom: ["searchMetricsPage", "query"] as const,
     },
 
+    AggregateTable: {
+      props: z.object({ maxRows: z.number().nullable() }),
+      hasChildren: false,
+      description:
+        "Tabular display of aggregate query results — dimension and measure " +
+        "columns from a `query` dataSource in aggregate mode (e.g. top spans " +
+        "by AVG(Duration), request counts grouped by StatusCode). Columns are " +
+        "derived from the result rows, so it renders any signal's aggregate output.",
+      acceptsDataFrom: ["query"] as const,
+    },
+
     MetricDiscovery: {
       props: z.object({}),
       hasChildren: false,

--- a/packages/ui-core/src/lib/observability-catalog.ts
+++ b/packages/ui-core/src/lib/observability-catalog.ts
@@ -154,13 +154,28 @@ export const observabilityCatalog = createCatalog({
     },
 
     AggregateTable: {
-      props: z.object({ maxRows: z.number().int().positive().nullable() }),
+      props: z.object({
+        maxRows: z.number().int().positive().nullable(),
+        units: z.record(z.string(), z.string()).nullable(),
+        labels: z.record(z.string(), z.string()).nullable(),
+      }),
       hasChildren: false,
       description:
         "Tabular display of aggregate query results — dimension and measure " +
         "columns from a `query` dataSource in aggregate mode (e.g. top spans " +
         "by AVG(Duration), request counts grouped by StatusCode). Columns are " +
-        "derived from the result rows, so it renders any signal's aggregate output.",
+        "derived from the result rows, so it renders any signal's aggregate output. " +
+        "`units` maps a column name to its OTel unit so the cell renders in " +
+        'human terms — e.g. {"avg_duration_ns": "ns"} shows 23070000 as ' +
+        '"23.07 ms". Understood units: ns/us/ms/s (duration ladder) and By ' +
+        "(binary byte ladder); unmapped columns keep generic SI scaling. " +
+        "Headers are humanised automatically — snake_case, dotted and " +
+        'PascalCase names become Title Case ("span_count" -> "Span Count"), ' +
+        "and a trailing unit token is dropped when that column is unit-annotated " +
+        '("avg_duration_ns" + "ns" -> "Avg Duration") since the unit already ' +
+        "shows in the cell. `labels` overrides the header for any column, which " +
+        "is the escape hatch when humanising mangles a name — e.g. " +
+        '{"SpanAttributes.http.route": "Route"}.',
       acceptsDataFrom: ["query"] as const,
     },
 

--- a/packages/ui/src/components/observability/DynamicDashboard/index.tsx
+++ b/packages/ui/src/components/observability/DynamicDashboard/index.tsx
@@ -16,6 +16,7 @@ import {
   Empty,
 } from "../../dashboard/index.js";
 import {
+  OtelAggregateTable,
   OtelLogTimeline,
   OtelMetricDiscovery,
   OtelMetricHistogram,
@@ -40,6 +41,7 @@ const MetricsRenderer = createRendererFromCatalog(observabilityCatalog, {
   MetricHistogram: OtelMetricHistogram,
   MetricStat: OtelMetricStat,
   MetricTable: OtelMetricTable,
+  AggregateTable: OtelAggregateTable,
   MetricDiscovery: OtelMetricDiscovery,
 });
 

--- a/packages/ui/src/components/observability/RawDataTable/index.tsx
+++ b/packages/ui/src/components/observability/RawDataTable/index.tsx
@@ -4,9 +4,24 @@
  */
 
 import type { RawTableData } from "../types.js";
+import { resolveUnitScale, formatDisplayValue } from "../utils/units.js";
 
 export interface RawDataTableProps {
   data: RawTableData;
+  /**
+   * Optional per-column OTel unit, positionally aligned with `data.columns`.
+   * A unit routes that column through the shared scale resolver — the same
+   * one the charts and MetricStat use — so `ns`/`us`/`ms`/`s` render as
+   * durations, `By` as bytes, `"1"` as a percent, and an unknown unit as a
+   * scaled number with the unit appended. A nullish entry keeps plain SI.
+   */
+  units?: (string | null | undefined)[];
+  /**
+   * Optional per-column display header, positionally aligned with
+   * `data.columns`. A nullish entry falls back to the raw column name — this
+   * component applies no naming policy of its own.
+   */
+  headers?: (string | null | undefined)[];
   maxRows?: number;
   isLoading?: boolean;
   error?: Error;
@@ -16,6 +31,10 @@ export interface RawDataTableProps {
 const SCALE_K = 1e3;
 const SCALE_M = 1e6;
 const SCALE_G = 1e9;
+
+// A column is read against its neighbours, so durations get a second digit
+// that a chart axis wouldn't bother with.
+const CELL_FRACTION_DIGITS = 2;
 
 function isNumericType(type: string | undefined): boolean {
   if (!type) return false;
@@ -30,15 +49,28 @@ function formatNumber(value: number): string {
   return value.toFixed(2);
 }
 
-function formatCell(value: unknown): string {
+// Unit-annotated cells go through the same scale resolver as MetricStat and
+// the chart axes, so one `By` value can't read as "5.24 MB" in a chart and
+// "5.00 MiB" in a table. Unannotated cells keep this component's own K/M/G
+// scaling — `resolveUnitScale(null)` would relabel 1.4e9 as "1.4 B", which
+// collides with bytes in a table that may hold both.
+function formatNumericCell(value: number, unit: string | null | undefined) {
+  if (!unit) return formatNumber(value);
+  const scale = resolveUnitScale(unit, Math.abs(value));
+  return formatDisplayValue(value, scale, CELL_FRACTION_DIGITS);
+}
+
+function formatCell(value: unknown, unit?: string | null): string {
   if (value === null || value === undefined) return "-";
-  if (typeof value === "number") return formatNumber(value);
+  if (typeof value === "number") return formatNumericCell(value, unit);
   if (typeof value === "object") return JSON.stringify(value);
   return String(value);
 }
 
 export function RawDataTable({
   data,
+  units,
+  headers,
   maxRows = 50,
   isLoading = false,
   error,
@@ -100,7 +132,7 @@ export function RawDataTable({
                   key={colIdx}
                   className={`px-4 py-3 font-medium whitespace-nowrap ${isNumericType(types[colIdx]) ? "text-right" : "text-left"}`}
                 >
-                  {col}
+                  {headers?.[colIdx] ?? col}
                 </th>
               ))}
             </tr>
@@ -113,7 +145,7 @@ export function RawDataTable({
                     key={colIdx}
                     className={`px-4 py-3 whitespace-nowrap ${isNumericType(types[colIdx]) ? "text-right text-foreground font-medium" : "text-foreground"}`}
                   >
-                    {formatCell(row[colIdx])}
+                    {formatCell(row[colIdx], units?.[colIdx])}
                   </td>
                 ))}
               </tr>

--- a/packages/ui/src/components/observability/renderers/OtelAggregateTable.test.tsx
+++ b/packages/ui/src/components/observability/renderers/OtelAggregateTable.test.tsx
@@ -300,6 +300,29 @@ describe("OtelAggregateTable", () => {
     expect(screen.getByText("Avg Duration Ms")).toBeTruthy();
   });
 
+  // The suffix is a camel-case token, not a delimited segment, so stripping it
+  // requires tokenising before the comparison.
+  it.each([
+    ["avgDurationNs", "Avg Duration"],
+    ["AvgDurationNs", "Avg Duration"],
+    ["avg_durationNs", "Avg Duration"],
+  ])("drops a camel-case unit suffix from %s", async (column, expected) => {
+    render(
+      createElement(DynamicDashboard, {
+        kopaiClient: clientReturning({
+          data: [{ SpanName: "x", calls: 1, [column]: 8080000 }],
+        }),
+        uiTree: treeWith({ [column]: "ns" }),
+      })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("raw-data-table")).toBeTruthy();
+    });
+    expect(screen.getByText(expected)).toBeTruthy();
+    expect(screen.getByText("8.08 ms")).toBeTruthy();
+  });
+
   it("keeps a unit-suffixed name when the column has no unit annotation", async () => {
     render(
       createElement(DynamicDashboard, {

--- a/packages/ui/src/components/observability/renderers/OtelAggregateTable.test.tsx
+++ b/packages/ui/src/components/observability/renderers/OtelAggregateTable.test.tsx
@@ -1,0 +1,388 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createElement } from "react";
+import { render, waitFor, screen } from "@testing-library/react";
+import { DynamicDashboard, type UITree } from "../DynamicDashboard/index.js";
+import { queryClient } from "@kopai/ui-core";
+import { kq } from "@kopai/sdk";
+
+// A real aggregate query — top span names by call count. Built with `kq` so the
+// uiTree's KopaiQuery schema validation exercises the same shape a dashboard
+// author would produce.
+const aggQuery = kq.traces
+  .aggregate()
+  .dimension("SpanName")
+  .measure((m) => m.count("calls"))
+  .measure((m) => m.avg("Duration", "avg_duration"))
+  .timeRelative("1h")
+  .summary()
+  .build();
+
+function treeWith(
+  units: Record<string, string> | null = null,
+  labels: Record<string, string> | null = null
+): UITree {
+  return {
+    root: "agg",
+    elements: {
+      agg: {
+        key: "agg",
+        type: "AggregateTable" as const,
+        children: [],
+        parentKey: "",
+        props: { maxRows: 10, units, labels },
+        dataSource: { method: "query" as const, params: aggQuery },
+      },
+    },
+  } satisfies UITree;
+}
+
+function clientReturning(data: unknown) {
+  return { query: vi.fn().mockResolvedValue(data) } as never;
+}
+
+describe("OtelAggregateTable", () => {
+  beforeEach(() => {
+    queryClient.clear();
+    vi.clearAllMocks();
+  });
+
+  it("renders dimension + measure columns from aggregate rows", async () => {
+    render(
+      createElement(DynamicDashboard, {
+        kopaiClient: clientReturning({
+          data: [
+            { SpanName: "trpc.uploadLogo", calls: 42, avg_duration: 2090.5 },
+            { SpanName: "GET /health", calls: 1200, avg_duration: 3 },
+          ],
+        }),
+        uiTree: treeWith(),
+      })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("raw-data-table")).toBeTruthy();
+    });
+    // Columns derived from the rows, in first-seen order, humanised.
+    expect(screen.getByText("Span Name")).toBeTruthy();
+    expect(screen.getByText("Calls")).toBeTruthy();
+    expect(screen.getByText("Avg Duration")).toBeTruthy();
+    // Values: strings verbatim, numbers scale-formatted by RawDataTable.
+    expect(screen.getByText("trpc.uploadLogo")).toBeTruthy();
+    expect(screen.getByText("1.20K")).toBeTruthy();
+  });
+
+  it("surfaces an explicit error when a RAW result is bound here", async () => {
+    render(
+      createElement(DynamicDashboard, {
+        kopaiClient: clientReturning({
+          data: [
+            { TimeUnix: "2024-01-01T00:00:00Z", Value: 1, Attributes: {} },
+          ],
+          nextCursor: null,
+        }),
+        uiTree: treeWith(),
+      })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("raw-data-table-error")).toBeTruthy();
+    });
+    expect(screen.getByText(/aggregate-mode query/)).toBeTruthy();
+  });
+
+  it("shows the empty state, not an error, for a zero-row aggregate", async () => {
+    render(
+      createElement(DynamicDashboard, {
+        kopaiClient: clientReturning({ data: [] }),
+        uiTree: treeWith(),
+      })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("raw-data-table-empty")).toBeTruthy();
+    });
+  });
+
+  // OTel span Duration is stored in nanoseconds, so an unannotated AVG(Duration)
+  // renders as "23.07M" — digits that happen to match the millisecond value,
+  // which is exactly what makes the generic SI suffix misleading.
+  it("renders a ns-annotated column as a duration instead of SI-scaled", async () => {
+    render(
+      createElement(DynamicDashboard, {
+        kopaiClient: clientReturning({
+          data: [
+            { SpanName: "process expire", calls: 12, avg_duration: 23070000 },
+          ],
+        }),
+        uiTree: treeWith({ avg_duration: "ns" }),
+      })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("raw-data-table")).toBeTruthy();
+    });
+    expect(screen.getByText("23.07 ms")).toBeTruthy();
+    expect(screen.queryByText("23.07M")).toBeNull();
+    // Unannotated columns keep the generic formatting.
+    expect(screen.getByText("12")).toBeTruthy();
+  });
+
+  it("walks the duration ladder from ns up to hours", async () => {
+    render(
+      createElement(DynamicDashboard, {
+        kopaiClient: clientReturning({
+          data: [
+            { SpanName: "sub-microsecond", calls: 1, avg_duration: 823 },
+            { SpanName: "micros", calls: 2, avg_duration: 4500 },
+            { SpanName: "millis", calls: 3, avg_duration: 8080000 },
+            { SpanName: "seconds", calls: 4, avg_duration: 1397820000 },
+            { SpanName: "minutes", calls: 5, avg_duration: 90e9 },
+            { SpanName: "hours", calls: 6, avg_duration: 7200e9 },
+          ],
+        }),
+        uiTree: treeWith({ avg_duration: "ns" }),
+      })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("raw-data-table")).toBeTruthy();
+    });
+    expect(screen.getByText("823 ns")).toBeTruthy();
+    expect(screen.getByText("4.50 μs")).toBeTruthy();
+    expect(screen.getByText("8.08 ms")).toBeTruthy();
+    expect(screen.getByText("1.40 s")).toBeTruthy();
+    expect(screen.getByText("1.50 min")).toBeTruthy();
+    // Whole numbers below 1e4 skip the decimals rather than reading "2.00 h".
+    expect(screen.getByText("2 h")).toBeTruthy();
+  });
+
+  it("normalises non-ns duration units before formatting", async () => {
+    render(
+      createElement(DynamicDashboard, {
+        kopaiClient: clientReturning({
+          data: [{ SpanName: "in millis", calls: 1, avg_duration: 1500 }],
+        }),
+        uiTree: treeWith({ avg_duration: "ms" }),
+      })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("raw-data-table")).toBeTruthy();
+    });
+    expect(screen.getByText("1.50 s")).toBeTruthy();
+  });
+
+  // Decimal, not binary — this is the shared resolver the charts use, so a
+  // byte count reads the same in a table as in a MetricStat.
+  it("formats a By-annotated column on the byte ladder", async () => {
+    render(
+      createElement(DynamicDashboard, {
+        kopaiClient: clientReturning({
+          data: [
+            { SpanName: "small", calls: 1, avg_duration: 512 },
+            { SpanName: "large", calls: 2, avg_duration: 5 * 1024 * 1024 },
+          ],
+        }),
+        uiTree: treeWith({ avg_duration: "By" }),
+      })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("raw-data-table")).toBeTruthy();
+    });
+    expect(screen.getByText("512 B")).toBeTruthy();
+    expect(screen.getByText("5.24 MB")).toBeTruthy();
+  });
+
+  // Inherited from the shared resolver: OTel's dimensionless unit is a ratio.
+  it("renders a '1'-annotated ratio column as a percentage", async () => {
+    render(
+      createElement(DynamicDashboard, {
+        kopaiClient: clientReturning({
+          data: [
+            { SpanName: "failing", calls: 12, error_rate: 1 },
+            { SpanName: "partial", calls: 50, error_rate: 0.42 },
+          ],
+        }),
+        uiTree: treeWith({ error_rate: "1" }),
+      })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("raw-data-table")).toBeTruthy();
+    });
+    expect(screen.getByText("100.00%")).toBeTruthy();
+    expect(screen.getByText("42.00%")).toBeTruthy();
+  });
+
+  it("scales an unknown unit generically and appends it", async () => {
+    render(
+      createElement(DynamicDashboard, {
+        kopaiClient: clientReturning({
+          data: [
+            { SpanName: "dimensionless", calls: 1, avg_duration: 2500000 },
+          ],
+        }),
+        uiTree: treeWith({ avg_duration: "{spans}" }),
+      })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("raw-data-table")).toBeTruthy();
+    });
+    expect(screen.getByText("2.50 M spans")).toBeTruthy();
+  });
+
+  it("humanises snake_case, dotted and PascalCase headers", async () => {
+    render(
+      createElement(DynamicDashboard, {
+        kopaiClient: clientReturning({
+          data: [
+            {
+              "service.name": "bova-worker",
+              SpanName: "process expire",
+              calls: 1,
+              error_rate: 0,
+            },
+          ],
+        }),
+        uiTree: treeWith(),
+      })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("raw-data-table")).toBeTruthy();
+    });
+    expect(screen.getByText("Service Name")).toBeTruthy();
+    expect(screen.getByText("Span Name")).toBeTruthy();
+    expect(screen.getByText("Error Rate")).toBeTruthy();
+  });
+
+  // The unit moved into the cell, so restating it in the header is noise.
+  it("drops a trailing unit token from a unit-annotated header", async () => {
+    render(
+      createElement(DynamicDashboard, {
+        kopaiClient: clientReturning({
+          data: [
+            { SpanName: "process expire", calls: 1, avg_duration_ns: 8080000 },
+          ],
+        }),
+        uiTree: treeWith({ avg_duration_ns: "ns" }),
+      })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("raw-data-table")).toBeTruthy();
+    });
+    expect(screen.getByText("Avg Duration")).toBeTruthy();
+    expect(screen.queryByText("Avg Duration Ns")).toBeNull();
+    expect(screen.getByText("8.08 ms")).toBeTruthy();
+  });
+
+  // Dropping a suffix the values contradict would relabel the column with a
+  // lie, so the drop only fires when name and annotation agree.
+  it("keeps a trailing unit token that disagrees with the annotated unit", async () => {
+    render(
+      createElement(DynamicDashboard, {
+        kopaiClient: clientReturning({
+          data: [{ SpanName: "x", calls: 1, avg_duration_ms: 1500 }],
+        }),
+        uiTree: treeWith({ avg_duration_ms: "ns" }),
+      })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("raw-data-table")).toBeTruthy();
+    });
+    expect(screen.getByText("Avg Duration Ms")).toBeTruthy();
+  });
+
+  it("keeps a unit-suffixed name when the column has no unit annotation", async () => {
+    render(
+      createElement(DynamicDashboard, {
+        kopaiClient: clientReturning({
+          data: [{ SpanName: "x", calls: 1, avg_duration_ns: 8080000 }],
+        }),
+        uiTree: treeWith(),
+      })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("raw-data-table")).toBeTruthy();
+    });
+    expect(screen.getByText("Avg Duration Ns")).toBeTruthy();
+  });
+
+  it("keeps acronym runs whole when humanising", async () => {
+    render(
+      createElement(DynamicDashboard, {
+        kopaiClient: clientReturning({
+          data: [{ HTTPRoute: "/health", p95: 3, calls: 1 }],
+        }),
+        uiTree: treeWith(),
+      })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("raw-data-table")).toBeTruthy();
+    });
+    expect(screen.getByText("HTTP Route")).toBeTruthy();
+    expect(screen.getByText("P95")).toBeTruthy();
+  });
+
+  // Humanising mangles dotted OTel attribute names; `labels` is the way out.
+  it("lets an explicit label override the humanised header", async () => {
+    render(
+      createElement(DynamicDashboard, {
+        kopaiClient: clientReturning({
+          data: [
+            {
+              "SpanAttributes.http.route": "/health",
+              calls: 1,
+              avg_duration_ns: 8080000,
+            },
+          ],
+        }),
+        uiTree: treeWith(
+          { avg_duration_ns: "ns" },
+          { "SpanAttributes.http.route": "Route", calls: "Requests" }
+        ),
+      })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("raw-data-table")).toBeTruthy();
+    });
+    expect(screen.getByText("Route")).toBeTruthy();
+    expect(screen.getByText("Requests")).toBeTruthy();
+    expect(screen.queryByText("Span Attributes Http Route")).toBeNull();
+    // Columns absent from `labels` still humanise.
+    expect(screen.getByText("Avg Duration")).toBeTruthy();
+  });
+
+  // Aliases are hand-written, so a units map will drift from the query it
+  // annotates. A stale entry must not shift the remaining columns' formatting,
+  // which is the failure mode of mapping units positionally instead of by name.
+  it("tolerates a units map that names a column the query does not return", async () => {
+    render(
+      createElement(DynamicDashboard, {
+        kopaiClient: clientReturning({
+          data: [
+            { SpanName: "process expire", calls: 1200, avg_duration: 8080000 },
+          ],
+        }),
+        uiTree: treeWith({ renamed_duration: "ns", avg_duration: "ns" }),
+      })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("raw-data-table")).toBeTruthy();
+    });
+    expect(screen.getByText("8.08 ms")).toBeTruthy();
+    // `calls` is unannotated and must stay SI-scaled, not absorb a unit.
+    expect(screen.getByText("1.20K")).toBeTruthy();
+  });
+});

--- a/packages/ui/src/components/observability/renderers/OtelAggregateTable.tsx
+++ b/packages/ui/src/components/observability/renderers/OtelAggregateTable.tsx
@@ -1,0 +1,63 @@
+import { observabilityCatalog } from "@kopai/ui-core";
+import type { RendererComponentProps } from "@kopai/ui-core";
+import type { kopaiQuery } from "@kopai/core";
+import { RawDataTable } from "../index.js";
+import type { RawTableData } from "../types.js";
+import { NoDataSource } from "./NoDataSource.js";
+import { narrowAggregateRows } from "./narrowRows.js";
+
+type Props = RendererComponentProps<
+  typeof observabilityCatalog.components.AggregateTable
+>;
+
+// Aggregate results are dynamic `Record<string, scalar>` rows — the columns
+// (dimensions + measures) vary per query — so they can't be drawn by the
+// signal-specific raw renderers. Flatten them into RawDataTable's
+// column/type/row shape: columns are the union of keys in first-seen order
+// (the datasource SELECTs dimensions before measures), and a column is typed
+// numeric only when every present value in it is a number, so RawDataTable
+// right-aligns + scale-formats measures while leaving dimension labels as text.
+function toTableData(rows: kopaiQuery.KopaiAggregateRow[]): RawTableData {
+  const columns: string[] = [];
+  const seen = new Set<string>();
+  for (const row of rows) {
+    for (const key of Object.keys(row)) {
+      if (!seen.has(key)) {
+        seen.add(key);
+        columns.push(key);
+      }
+    }
+  }
+
+  const types = columns.map((col) => {
+    let sawValue = false;
+    for (const row of rows) {
+      const val = row[col];
+      if (val === null || val === undefined) continue;
+      sawValue = true;
+      if (typeof val !== "number") return "String";
+    }
+    return sawValue ? "Float" : "String";
+  });
+
+  const dataRows = rows.map((row) => columns.map((col) => row[col] ?? null));
+  return { columns, types, rows: dataRows };
+}
+
+export function OtelAggregateTable(props: Props) {
+  if (!props.hasData) return <NoDataSource />;
+
+  // `query` is polymorphic — accept aggregate-mode rows and surface an explicit
+  // error (rather than JSON-stringifying object columns) when a raw-shaped
+  // result is bound here, mirroring the raw renderers' shape validation.
+  const { rows, error } = narrowAggregateRows(props.response);
+
+  return (
+    <RawDataTable
+      data={toTableData(rows)}
+      isLoading={props.loading}
+      error={props.error ?? error}
+      maxRows={props.element.props.maxRows ?? 100}
+    />
+  );
+}

--- a/packages/ui/src/components/observability/renderers/OtelAggregateTable.tsx
+++ b/packages/ui/src/components/observability/renderers/OtelAggregateTable.tsx
@@ -44,6 +44,85 @@ function toTableData(rows: kopaiQuery.KopaiAggregateRow[]): RawTableData {
   return { columns, types, rows: dataRows };
 }
 
+// The `units` prop is keyed by column name, but RawDataTable formats by
+// position — measures carry no unit metadata through the query layer, so the
+// dashboard author supplies it. Columns absent from the map format normally,
+// which is what lets a units map drift from its query without breaking the
+// other columns. `Object.hasOwn` is belt-and-braces: the catalog's
+// `z.record` parse already yields a fresh plain object.
+function unitsByColumn(
+  columns: string[],
+  units: Record<string, string> | null | undefined
+): (string | null)[] | undefined {
+  if (!units) return undefined;
+  return columns.map((col) => lookup(units, col));
+}
+
+function lookup(record: Record<string, string>, key: string): string | null {
+  return Object.hasOwn(record, key) ? (record[key] ?? null) : null;
+}
+
+// Segment tokens a column name may carry that restate its annotated unit.
+// Keyed by the OTel unit, since the drop only fires when the two agree —
+// "duration_ms" annotated as "ns" keeps its suffix rather than being
+// silently relabelled to something the values contradict.
+// Keys are the units `resolveUnitScale` actually recognises — annotating a
+// column with anything else leaves the name alone, matching the fact that
+// the cell won't be unit-formatted either.
+const UNIT_NAME_TOKENS = new Map<string, readonly string[]>([
+  ["ns", ["ns", "nanos", "nanoseconds"]],
+  ["us", ["us", "micros", "microseconds"]],
+  ["ms", ["ms", "millis", "milliseconds"]],
+  ["s", ["s", "sec", "secs", "seconds"]],
+  ["By", ["by", "b", "bytes"]],
+]);
+
+/** Splits PascalCase/camelCase, keeping acronym runs whole: HTTPRoute -> HTTP Route. */
+function splitCamel(segment: string): string[] {
+  return segment
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
+    .replace(/([a-z\d])([A-Z])/g, "$1 $2")
+    .split(" ")
+    .filter(Boolean);
+}
+
+/** All-caps and alphanumeric runs (HTTP, P95) keep their case; others Title Case. */
+function capitalize(word: string): string {
+  if (/^[A-Z0-9]+$/.test(word)) return word;
+  return word.charAt(0).toUpperCase() + word.slice(1);
+}
+
+/**
+ * Turns a raw column name into a display header: `span_count` -> "Span Count",
+ * `service.name` -> "Service Name", `SpanName` -> "Span Name". When the column
+ * is unit-annotated and its last segment restates that unit, the segment is
+ * dropped — `avg_duration_ns` + `ns` -> "Avg Duration" — because the formatted
+ * cell already carries the unit.
+ */
+function humanize(column: string, unit: string | null): string {
+  const segments = column.split(/[._]+/).filter(Boolean);
+  const tokens = unit ? UNIT_NAME_TOKENS.get(unit) : undefined;
+  const last = segments[segments.length - 1]?.toLowerCase();
+  if (tokens && segments.length > 1 && last && tokens.includes(last)) {
+    segments.pop();
+  }
+  return segments.flatMap(splitCamel).map(capitalize).join(" ");
+}
+
+// Explicit `labels` win outright; everything else is humanised. Kept here
+// rather than in RawDataTable so the naming policy lives beside the props
+// that drive it and the table stays a dumb renderer.
+function headersByColumn(
+  columns: string[],
+  units: (string | null)[] | undefined,
+  labels: Record<string, string> | null | undefined
+): string[] {
+  return columns.map((col, idx) => {
+    const override = labels ? lookup(labels, col) : null;
+    return override ?? humanize(col, units?.[idx] ?? null);
+  });
+}
+
 export function OtelAggregateTable(props: Props) {
   if (!props.hasData) return <NoDataSource />;
 
@@ -51,10 +130,14 @@ export function OtelAggregateTable(props: Props) {
   // error (rather than JSON-stringifying object columns) when a raw-shaped
   // result is bound here, mirroring the raw renderers' shape validation.
   const { rows, error } = narrowAggregateRows(props.response);
+  const data = toTableData(rows);
+  const units = unitsByColumn(data.columns, props.element.props.units);
 
   return (
     <RawDataTable
-      data={toTableData(rows)}
+      data={data}
+      units={units}
+      headers={headersByColumn(data.columns, units, props.element.props.labels)}
       isLoading={props.loading}
       error={props.error ?? error}
       maxRows={props.element.props.maxRows ?? 100}

--- a/packages/ui/src/components/observability/renderers/OtelAggregateTable.tsx
+++ b/packages/ui/src/components/observability/renderers/OtelAggregateTable.tsx
@@ -100,13 +100,15 @@ function capitalize(word: string): string {
  * cell already carries the unit.
  */
 function humanize(column: string, unit: string | null): string {
-  const segments = column.split(/[._]+/).filter(Boolean);
+  // Tokenise before testing the trailing unit: splitting on delimiters alone
+  // leaves `avgDurationNs` as a single segment, so the suffix would survive.
+  const words = column.split(/[._]+/).filter(Boolean).flatMap(splitCamel);
   const tokens = unit ? UNIT_NAME_TOKENS.get(unit) : undefined;
-  const last = segments[segments.length - 1]?.toLowerCase();
-  if (tokens && segments.length > 1 && last && tokens.includes(last)) {
-    segments.pop();
+  const last = words[words.length - 1]?.toLowerCase();
+  if (tokens && words.length > 1 && last && tokens.includes(last)) {
+    words.pop();
   }
-  return segments.flatMap(splitCamel).map(capitalize).join(" ");
+  return words.map(capitalize).join(" ");
 }
 
 // Explicit `labels` win outright; everything else is humanised. Kept here

--- a/packages/ui/src/components/observability/renderers/index.ts
+++ b/packages/ui/src/components/observability/renderers/index.ts
@@ -1,3 +1,4 @@
+export { OtelAggregateTable } from "./OtelAggregateTable.js";
 export { OtelLogTimeline } from "./OtelLogTimeline.js";
 export { OtelMetricDiscovery } from "./OtelMetricDiscovery.js";
 export { OtelMetricHistogram } from "./OtelMetricHistogram.js";

--- a/packages/ui/src/components/observability/renderers/narrowRows.test.ts
+++ b/packages/ui/src/components/observability/renderers/narrowRows.test.ts
@@ -204,6 +204,36 @@ describe("row shape guards", () => {
       })
     ).toBe(false);
   });
+
+  // An aggregate may group by a column the raw guards key on. Verified against
+  // a live backend: `kq.metrics("Gauge").aggregate().dimension("TimeUnix")`
+  // returns `{ TimeUnix: "1786017799669000000", n: 101 }`, which the bare
+  // TimeUnix check would misread as a raw metric row and send to the error path.
+  it("hasAggregateRowShape accepts aggregates grouped by raw-signal columns", () => {
+    expect(
+      hasAggregateRowShape({ TimeUnix: "1786017799669000000", n: 101 })
+    ).toBe(true);
+    // Log/trace-flavoured dimensions likewise: no raw Timestamp, so no veto.
+    expect(hasAggregateRowShape({ Body: "job failed", n: 3 })).toBe(true);
+    expect(hasAggregateRowShape({ SpanId: "0033932b485499f8", n: 1 })).toBe(
+      true
+    );
+    expect(hasAggregateRowShape({ StatusCode: "Error", Duration: 12 })).toBe(
+      true
+    );
+    // A real raw metric row still carries its value/identity columns and is
+    // still rejected — each companion key alone is enough to veto.
+    for (const companion of [
+      { Value: 1 },
+      { MetricName: "m" },
+      { MetricType: "Gauge" },
+      { StartTimeUnix: "1" },
+    ]) {
+      expect(
+        hasAggregateRowShape({ TimeUnix: "1786017799669000000", ...companion })
+      ).toBe(false);
+    }
+  });
 });
 
 // narrowAggregateRows is the inverse of narrowQueryRows: it forwards

--- a/packages/ui/src/components/observability/renderers/narrowRows.test.ts
+++ b/packages/ui/src/components/observability/renderers/narrowRows.test.ts
@@ -2,9 +2,11 @@ import { describe, it, expect } from "vitest";
 import {
   narrowRows,
   narrowQueryRows,
+  narrowAggregateRows,
   hasMetricRowShape,
   hasLogRowShape,
   hasTraceRowShape,
+  hasAggregateRowShape,
 } from "./narrowRows.js";
 
 // L6/L9: the polymorphic `query` dataSource can feed any of the six result
@@ -160,5 +162,55 @@ describe("row shape guards", () => {
     expect(hasTraceRowShape({ SpanId: "s", TraceId: "t", SpanName: "x" })).toBe(
       false
     );
+  });
+
+  it("hasAggregateRowShape accepts flat scalar rows and rejects raw rows", () => {
+    // Dimension + measure columns, all scalar.
+    expect(hasAggregateRowShape({ SpanName: "trpc.x", calls: 3 })).toBe(true);
+    expect(hasAggregateRowShape({ StatusCode: "Error", requests: 0 })).toBe(
+      true
+    );
+    // timeSeries aggregate adds a scalar bucket_start.
+    expect(hasAggregateRowShape({ bucket_start: "2024-01-01", value: 1 })).toBe(
+      true
+    );
+    expect(hasAggregateRowShape({ value: null })).toBe(true);
+    // Raw rows carry object/array-valued fields — must NOT pass.
+    expect(hasAggregateRowShape({ ...metricRow, Attributes: {} })).toBe(false);
+    expect(
+      hasAggregateRowShape({ SpanName: "x", ResourceAttributes: {} })
+    ).toBe(false);
+    expect(
+      hasAggregateRowShape({ MetricName: "m", "Exemplars.Value": [] })
+    ).toBe(false);
+    expect(hasAggregateRowShape(null)).toBe(false);
+  });
+});
+
+// narrowAggregateRows is the inverse of narrowQueryRows: it forwards
+// aggregate-shaped rows and surfaces an explicit error when a *raw* result is
+// bound to an aggregate renderer by mistake.
+describe("narrowAggregateRows", () => {
+  it("forwards aggregate rows with no error", () => {
+    const res = { data: [{ SpanName: "trpc.uploadLogo", avg_duration: 2090 }] };
+    const out = narrowAggregateRows(res);
+    expect(out.rows).toHaveLength(1);
+    expect(out.error).toBeUndefined();
+  });
+
+  it("surfaces an error when a raw metric result reaches an aggregate renderer", () => {
+    const res = {
+      data: [{ TimeUnix: "1", Value: 1, Attributes: { a: "b" } }],
+    };
+    const out = narrowAggregateRows(res);
+    expect(out.rows).toEqual([]);
+    expect(out.error).toBeInstanceOf(Error);
+    expect(out.error?.message).toContain('mode: "aggregate"');
+  });
+
+  it("does NOT error on empty or null responses", () => {
+    expect(narrowAggregateRows({ data: [] }).error).toBeUndefined();
+    expect(narrowAggregateRows(null).error).toBeUndefined();
+    expect(narrowAggregateRows({ data: undefined }).error).toBeUndefined();
   });
 });

--- a/packages/ui/src/components/observability/renderers/narrowRows.test.ts
+++ b/packages/ui/src/components/observability/renderers/narrowRows.test.ts
@@ -184,6 +184,25 @@ describe("row shape guards", () => {
       hasAggregateRowShape({ MetricName: "m", "Exemplars.Value": [] })
     ).toBe(false);
     expect(hasAggregateRowShape(null)).toBe(false);
+    // Scalar-only rows that still match a raw-signal guard are rejected, so a
+    // raw result bound to an aggregate renderer surfaces the config error
+    // rather than rendering silently.
+    expect(
+      hasAggregateRowShape({ TimeUnix: "1", MetricName: "m", Value: 1 })
+    ).toBe(false);
+    expect(
+      hasAggregateRowShape({ Timestamp: "1", Body: "hi", SeverityText: "INFO" })
+    ).toBe(false);
+    expect(
+      hasAggregateRowShape({
+        Timestamp: "1",
+        SpanId: "s",
+        TraceId: "t",
+        SpanName: "x",
+        Duration: 5,
+        StatusCode: "Ok",
+      })
+    ).toBe(false);
   });
 });
 
@@ -206,6 +225,16 @@ describe("narrowAggregateRows", () => {
     expect(out.rows).toEqual([]);
     expect(out.error).toBeInstanceOf(Error);
     expect(out.error?.message).toContain('mode: "aggregate"');
+  });
+
+  it("errors on a scalar-only raw result with no object-valued fields", () => {
+    // A raw metric row whose attribute columns are absent is all-scalar, but
+    // still matches the raw metric guard — it must not slip through as aggregate.
+    const out = narrowAggregateRows({
+      data: [{ TimeUnix: "1", MetricName: "m", Value: 1 }],
+    });
+    expect(out.rows).toEqual([]);
+    expect(out.error).toBeInstanceOf(Error);
   });
 
   it("does NOT error on empty or null responses", () => {

--- a/packages/ui/src/components/observability/renderers/narrowRows.ts
+++ b/packages/ui/src/components/observability/renderers/narrowRows.ts
@@ -142,6 +142,26 @@ export function hasTraceRowShape(v: unknown): v is OtelTracesRow {
   );
 }
 
+// `hasMetricRowShape` keys on TimeUnix alone, which is right for raw rendering
+// but too broad here: a metrics aggregate may legitimately group by TimeUnix,
+// producing `{ TimeUnix, <measures> }` — a valid aggregate row that the metric
+// guard would veto, routing a working query to the mismatch error. A genuine
+// raw metric row always carries its value/identity columns alongside the
+// timestamp (both datasources SELECT every column), so require one of those
+// before treating a TimeUnix-bearing row as raw. The log and trace guards need
+// no such narrowing — they already demand a raw `Timestamp` plus a
+// signal-exclusive key, which no aggregate row carries.
+const RAW_METRIC_COMPANION_KEYS = [
+  "Value",
+  "MetricName",
+  "MetricType",
+  "StartTimeUnix",
+];
+
+function looksRawMetric(v: Record<string, unknown>): boolean {
+  return hasMetricRowShape(v) && hasAnyKey(v, RAW_METRIC_COMPANION_KEYS);
+}
+
 // Aggregate rows (KopaiAggregateRow) are flat records of scalar cells — the
 // query's dimension and measure columns. Raw signal rows normally carry a
 // non-scalar field (Attributes/ResourceAttributes objects, Exemplars arrays),
@@ -154,7 +174,7 @@ export function hasTraceRowShape(v: unknown): v is OtelTracesRow {
 // bucket_start).
 export function hasAggregateRowShape(v: unknown): v is KopaiAggregateRow {
   if (!isRecord(v)) return false;
-  if (hasMetricRowShape(v) || hasLogRowShape(v) || hasTraceRowShape(v)) {
+  if (looksRawMetric(v) || hasLogRowShape(v) || hasTraceRowShape(v)) {
     return false;
   }
   for (const val of Object.values(v)) {

--- a/packages/ui/src/components/observability/renderers/narrowRows.ts
+++ b/packages/ui/src/components/observability/renderers/narrowRows.ts
@@ -1,8 +1,9 @@
-import type { denormalizedSignals } from "@kopai/core";
+import type { denormalizedSignals, kopaiQuery } from "@kopai/core";
 
 type OtelTracesRow = denormalizedSignals.OtelTracesRow;
 type OtelLogsRow = denormalizedSignals.OtelLogsRow;
 type OtelMetricsRow = denormalizedSignals.OtelMetricsRow;
+type KopaiAggregateRow = kopaiQuery.KopaiAggregateRow;
 
 // The polymorphic `query` dataSource method can return any of the six
 // KopaiQuery result shapes. A signal-specific renderer must therefore validate
@@ -55,6 +56,28 @@ export function narrowQueryRows<T>(
       `This panel displays raw ${signal} rows, but the query returned a different ` +
         `row shape — typically an aggregate-mode query, or a query for another signal. ` +
         `Use a raw ${signal} query, or a renderer that supports aggregate results.`
+    ),
+  };
+}
+
+// The inverse of the raw-row narrowers: an *aggregate* renderer accepts the
+// dynamic dimension/measure rows produced by a `mode: "aggregate"` query and
+// must reject a raw signal result bound to it by mistake. `narrowAggregateRows`
+// returns null → an explicit error when the rows are raw-shaped, matching the
+// raw renderers' behaviour so the misconfiguration is visible rather than
+// silently rendering object-valued columns as JSON.
+export function narrowAggregateRows(
+  response: { data?: unknown } | null | undefined
+): { rows: KopaiAggregateRow[]; error?: Error } {
+  const rows = narrowRows(response, hasAggregateRowShape);
+  if (rows !== null) return { rows };
+  if (!Array.isArray(response?.data)) return { rows: [] };
+  return {
+    rows: [],
+    error: new Error(
+      `This panel displays aggregate query results, but the query returned rows ` +
+        `with a raw (non-scalar) shape — typically a raw-mode query or a raw ` +
+        `metric/trace/log source. Use an aggregate-mode query (mode: "aggregate").`
     ),
   };
 }
@@ -117,4 +140,19 @@ export function hasTraceRowShape(v: unknown): v is OtelTracesRow {
     hasAnyKey(v, SPAN_ONLY_KEYS) &&
     !hasAnyKey(v, LOG_ONLY_KEYS)
   );
+}
+
+// Aggregate rows (KopaiAggregateRow) are flat records of scalar cells — the
+// query's dimension and measure columns. Raw signal rows always carry at least
+// one non-scalar field (Attributes/ResourceAttributes objects, Exemplars
+// arrays), so "every value is string | number | null" is the reliable
+// discriminator between an aggregate result and a raw metric/trace/log row.
+export function hasAggregateRowShape(v: unknown): v is KopaiAggregateRow {
+  if (!isRecord(v)) return false;
+  for (const val of Object.values(v)) {
+    if (val !== null && typeof val !== "string" && typeof val !== "number") {
+      return false;
+    }
+  }
+  return true;
 }

--- a/packages/ui/src/components/observability/renderers/narrowRows.ts
+++ b/packages/ui/src/components/observability/renderers/narrowRows.ts
@@ -143,12 +143,20 @@ export function hasTraceRowShape(v: unknown): v is OtelTracesRow {
 }
 
 // Aggregate rows (KopaiAggregateRow) are flat records of scalar cells — the
-// query's dimension and measure columns. Raw signal rows always carry at least
-// one non-scalar field (Attributes/ResourceAttributes objects, Exemplars
-// arrays), so "every value is string | number | null" is the reliable
-// discriminator between an aggregate result and a raw metric/trace/log row.
+// query's dimension and measure columns. Raw signal rows normally carry a
+// non-scalar field (Attributes/ResourceAttributes objects, Exemplars arrays),
+// but a raw row can also be all-scalar (e.g. a metric row with no attributes)
+// and would then match a raw-signal guard. Reject anything the raw guards
+// already claim before accepting a scalar-only record, so a raw result bound
+// to an aggregate renderer surfaces the config error instead of rendering
+// silently. This is safe for real aggregate rows: the raw guards require a raw
+// TimeUnix/Timestamp column, which aggregate results never have (they use
+// bucket_start).
 export function hasAggregateRowShape(v: unknown): v is KopaiAggregateRow {
   if (!isRecord(v)) return false;
+  if (hasMetricRowShape(v) || hasLogRowShape(v) || hasTraceRowShape(v)) {
+    return false;
+  }
   for (const val of Object.values(v)) {
     if (val !== null && typeof val !== "string" && typeof val !== "number") {
       return false;

--- a/packages/ui/src/components/observability/utils/units.test.ts
+++ b/packages/ui/src/components/observability/utils/units.test.ts
@@ -114,3 +114,47 @@ describe("formatOtelValue", () => {
     expect(formatOtelValue(42, "")).toBe("42");
   });
 });
+
+// OTel span Duration is nanoseconds. Before `ns` had a scale family it fell
+// through to generic scaling and rendered as "23.1 M ns".
+describe("nanosecond scaling", () => {
+  it.each([
+    [823, "823 ns"],
+    [4_500, "4.5 μs"],
+    [23_070_000, "23.1 ms"],
+    [1_397_820_000, "1.4 s"],
+    [90e9, "1.5 min"],
+    [7_200e9, "2 h"],
+  ])("formats %i ns as %s", (value, expected) => {
+    expect(formatOtelValue(value, "ns")).toBe(expected);
+  });
+
+  it("does not leave a raw 'ns' suffix on a scaled value", () => {
+    expect(formatOtelValue(23_070_000, "ns")).not.toContain("M ns");
+  });
+});
+
+describe("fractionDigits", () => {
+  it("defaults to one digit", () => {
+    const s = resolveUnitScale("ns", 23_070_000);
+    expect(formatDisplayValue(23_070_000, s)).toBe("23.1 ms");
+    expect(formatTickValue(23_070_000, s)).toBe("23.1");
+  });
+
+  it("honours a caller-supplied precision", () => {
+    const s = resolveUnitScale("ns", 23_070_000);
+    expect(formatDisplayValue(23_070_000, s, 2)).toBe("23.07 ms");
+    expect(formatTickValue(23_070_000, s, 2)).toBe("23.07");
+  });
+
+  it("applies precision to percents too", () => {
+    const s = resolveUnitScale("1", 0.4242);
+    expect(formatDisplayValue(0.4242, s)).toBe("42.4%");
+    expect(formatDisplayValue(0.4242, s, 2)).toBe("42.42%");
+  });
+
+  it("keeps whole numbers whole regardless of precision", () => {
+    const s = resolveUnitScale("By", 512);
+    expect(formatDisplayValue(512, s, 2)).toBe("512 B");
+  });
+});

--- a/packages/ui/src/components/observability/utils/units.ts
+++ b/packages/ui/src/components/observability/utils/units.ts
@@ -37,6 +37,17 @@ const US_SCALES: ScaleEntry[] = [
   { threshold: 0, divisor: 1, suffix: "\u03BCs" },
 ];
 
+// OTel span Duration is nanoseconds, so this ladder runs the full range:
+// without it, `ns` falls through to generic scaling and reads "23.1 M ns".
+const NS_SCALES: ScaleEntry[] = [
+  { threshold: 3600e9, divisor: 3600e9, suffix: "h" },
+  { threshold: 60e9, divisor: 60e9, suffix: "min" },
+  { threshold: 1e9, divisor: 1e9, suffix: "s" },
+  { threshold: 1e6, divisor: 1e6, suffix: "ms" },
+  { threshold: 1e3, divisor: 1e3, suffix: "\u03BCs" },
+  { threshold: 0, divisor: 1, suffix: "ns" },
+];
+
 const GENERIC_SCALES: ScaleEntry[] = [
   { threshold: 1e9, divisor: 1e9, suffix: "B" },
   { threshold: 1e6, divisor: 1e6, suffix: "M" },
@@ -51,6 +62,7 @@ const UNIT_SCALE_MAP: Record<string, ScaleEntry[]> = {
   s: SECOND_SCALES,
   ms: MS_SCALES,
   us: US_SCALES,
+  ns: NS_SCALES,
 };
 
 function pickScale(scales: ScaleEntry[], maxValue: number): ScaleEntry {
@@ -107,19 +119,30 @@ export function resolveUnitScale(
   return { divisor: s.divisor, suffix, label: unit, isPercent: false };
 }
 
-export function formatTickValue(value: number, scale: ResolvedScale): string {
+/**
+ * `fractionDigits` defaults to 1, which suits axis ticks and KPI cards where
+ * space is tight. Tables pass 2 — a column of durations is read against its
+ * neighbours, so the extra digit distinguishes rows that a single digit
+ * rounds together.
+ */
+export function formatTickValue(
+  value: number,
+  scale: ResolvedScale,
+  fractionDigits = 1
+): string {
   const scaled = value / scale.divisor;
-  if (scale.isPercent) return `${scaled.toFixed(1)}`;
+  if (scale.isPercent) return `${scaled.toFixed(fractionDigits)}`;
   if (Number.isInteger(scaled) && Math.abs(scaled) < 1e4)
     return scaled.toString();
-  return scaled.toFixed(1);
+  return scaled.toFixed(fractionDigits);
 }
 
 export function formatDisplayValue(
   value: number,
-  scale: ResolvedScale
+  scale: ResolvedScale,
+  fractionDigits = 1
 ): string {
-  const tick = formatTickValue(value, scale);
+  const tick = formatTickValue(value, scale, fractionDigits);
   if (!scale.suffix) return tick;
   if (scale.isPercent) return `${tick}${scale.suffix}`;
   return `${tick} ${scale.suffix}`;


### PR DESCRIPTION
---
Summary

Adds an AggregateTable dashboard component that renders aggregate-mode query results (dimension + measure columns) as a table, with unit-aware cells and automatically humanised headers.

Previously every data-bound SDUI renderer validated for raw signal rows, so an aggregate query — e.g. top spans by AVG(Duration), or request counts grouped by StatusCode — had no renderer, and if bound to MetricTable it failed at render with "This panel displays raw metric rows…". AggregateTable accepts the polymorphic aggregate result and derives its columns from the rows, so any signal's aggregate output can be displayed.

Because those columns come from the query rather than a fixed schema, the component carries no unit or naming metadata of its own. Two further props supply it.

Why the annotation props exist

OTel stores span Duration in nanoseconds. An unannotated AVG(Duration) of 23070000 renders as 23.07M — digits that coincidentally match the millisecond value, which is exactly what makes the bare SI suffix misleading. Annotated, the same cell reads 23.07 ms.

Following the rest of the catalog, both props are nullable but must be present — pass null when unused.

props: {
  maxRows: 10,
  units: { avg_duration_ns: "ns", error_rate: "1" },
  labels: null,
}

units maps a column name to its OTel unit and resolves through the same scale resolver the charts and MetricStat already use — so one byte count can no longer read as 5.24 MB in a chart and 5.00 MiB in a table. ns/us/ms/s render as durations, By as bytes, "1" as a percentage, and an unknown unit as a scaled number with the unit appended ({spans} → 2.50 M spans). Unannotated columns keep plain K/M/G scaling.

labels overrides the header for any column. Headers are otherwise derived automatically: snake_case, dotted and PascalCase names become Title Case (span_count → "Span Count", SpanName → "Span Name"), acronym runs stay whole (HTTPRoute → "HTTP Route"), and a trailing unit token is dropped when the column is unit-annotated (avg_duration_ns + ns → "Avg Duration"), since the unit already appears in the cell. The drop only fires when name and annotation agree — avg_duration_ms annotated ns keeps its suffix rather than being relabelled to something the values contradict.

Humanising flattens dotted OTel attribute names (SpanAttributes.http.route → "Span Attributes Http Route"). That's the case labels exists to fix.

What changed

- @kopai/ui-core — new AggregateTable component in the observability catalog, bound to the query dataSource, with maxRows, units and labels props.
- @kopai/ui
  - OtelAggregateTable renderer — flattens KopaiAggregateRow[] into RawDataTable's column/type/row shape (columns in first-seen order; a column is typed numeric only when every present value is a number). Owns the header-naming policy.
  - narrowAggregateRows / hasAggregateRowShape — forward scalar aggregate rows and surface an explicit error when a raw-shaped result is bound by mistake, mirroring the raw renderers' shape validation.
  - RawDataTable — new internal units and headers props; applies no naming policy of its own.
  - utils/units.ts — added an ns scale family and an optional fractionDigits argument (defaults to 1, so existing callers are unchanged; tables pass 2).
  - Wired OtelAggregateTable into DynamicDashboard.
- examples/ui-react-app — registered the matching example renderer; the kitchen-sink demo annotates its nanosecond column.
- Changeset: @kopai/ui-core and @kopai/ui bumped minor (additive).

Behaviour change outside AggregateTable

Nanoseconds previously had no scale family, so any metric with OTel unit ns fell through to generic scaling and rendered as 23.1 M ns. It now renders as 23.1 ms. This affects MetricStat, MetricTimeSeries and MetricHistogram as well as the new table. No other unit changes behaviour — the pre-existing units.test.ts cases pass unmodified.

Test plan

- OtelAggregateTable.test.tsx (16) — column derivation, raw-result and empty-result handling, the duration ladder ns→h, non-ns unit normalisation, bytes, percentages, unknown units, header humanising, unit-suffix dropping (including the disagreement case), acronym runs, and labels overrides.
- narrowRows.test.ts (20) — hasAggregateRowShape accepts flat scalar rows / rejects raw rows; narrowAggregateRows forwards aggregate rows, errors on a raw result, and no-ops on empty/null responses.
- units.test.ts (30) — extended with nanosecond scaling and fractionDigits coverage.
- pnpm --filter @kopai/ui test — 118 passing. @kopai/ui-core — 62 passing.
- pnpm type-check — 20/20 clean. pnpm lint and prettier clean.
- Verified end-to-end against a live Kopai backend: dashboard created via the SDK passes observabilityCatalog.uiTreeSchema.safeParse (the same gate observability.tsx runs at render) and the tiles render real trace data.

---