### PR TITLE
feat(skills): add Fastify recipe to otel-instrumentation, fix CLI field names

### DIFF
--- a/skills/otel-instrumentation/CHANGELOG.md
+++ b/skills/otel-instrumentation/CHANGELOG.md
@@ -1,0 +1,35 @@
+# kopai/otel-instrumentation
+
+## 2.1.0
+
+### Minor Changes
+
+- #163: Add a Fastify recipe (`references/lang-fastify.md`) built on `@fastify/otel`, registered explicitly through `app.register(fastifyOtel.plugin())` instead of module interception. Covers the Fastify `>=4 <6` support gate, ESM semantics (CommonJS dependencies patch via the require hook; native-ESM dependencies need `--experimental-loader=@opentelemetry/instrumentation/hook.mjs`), why `registerOnInitialization` and manual plugin registration must never be combined, and a scope-based validation assertion (`--scope "@fastify/otel"`) that catches silent plugin-registration failures which HTTP-layer telemetry masks.
+
+  Motivated by dogfooding: the deprecated `@opentelemetry/instrumentation-fastify` was removed from `auto-instrumentations-node` in March 2026, so the generic Node.js recipe produces no Fastify-layer spans — and no error.
+
+- #163: Add a "Picking instrumentation packages" rule to SKILL.md: detect the project's package manager (`packageManager` field, then lockfile) and install with it, check `npm view <pkg> deprecated` against the registry before wiring a package (only npm prints deprecation warnings at install — pnpm truncates them, Yarn 4 prints none), and prefer framework-native plugins over contrib interception. `troubleshoot-missing-spans.md` gains the matching silent-failure causes (native-ESM dependencies, deprecated instrumentation packages), and `lang-nodejs.md` now routes Fastify apps to the new recipe and documents the ESM loader hook.
+
+### Patch Changes
+
+- #163: Correct the `jq` field defaults across the validate/troubleshoot references to the CLI's actual row names (`SpanName`, `TraceId`, `ParentSpanId`, `SpanAttributes`, `Body`, …). The OTLP-style lowercase names read `null`, and the orphan check selected every span as an orphan. Metrics `discover` keeps lowercase names — that output shape differs and was already correct. The "Calibrate once" note in `validate-traces.md` stays as the escape hatch for future shape changes.
+
+## 2.0.0
+
+### Major Changes
+
+- b3f1b16: Rewrite the skill around a self-validating loop (#158). Validation becomes executable rather than "did any data show up": a `validation.run_id` resource attribute tags each run, the agent drives traffic itself including deliberate failures (`drive-traffic.md`), and `validate-traces.md` asserts nine pass/fail checks (orphans, trace depth, route coverage, cardinality, error status and slug, attribute inventory, leftover test spans), with `validate-logs.md`, `validate-metrics.md`, and `validate-shutdown.md` covering correlation, severity, cardinality, and flush on SIGTERM.
+
+  Adds the judgment layer SDK setup never covered: what earns a span, which attributes to attach, error conventions (`error`, span status, `exception.slug`), context propagation and framework accessor traps, sampling, and signal selection. New references: the attribute catalog, per-language custom instrumentation patterns, and trace design for queues, async fan-out, ETL, and serverless. The `rules/` directory is flattened into `references/`.
+
+## 1.1.0
+
+### Minor Changes
+
+- 3894c34: Document the new CLI metrics-aggregation parameters in `cli-reference.md` (#105).
+
+## 1.0.0
+
+### Major Changes
+
+- 79dc63c: Initial version of the skill: OpenTelemetry SDK setup recipes per language, Kopai backend setup, and CLI validation guidance. First published to Tessl in #99–#103.

--- a/skills/otel-instrumentation/SKILL.md
+++ b/skills/otel-instrumentation/SKILL.md
@@ -4,7 +4,7 @@ description: Instrument applications with the OpenTelemetry SDK and prove the te
 license: Apache-2.0
 metadata:
   author: kopai
-  version: "2.0.0"
+  version: "2.1.0"
 ---
 
 # OpenTelemetry Instrumentation with Kopai
@@ -100,13 +100,43 @@ in [custom-instrumentation](references/custom-instrumentation.md).
 Span names must be low-cardinality. Never interpolate an ID into a span name — that
 belongs in an attribute.
 
+## Picking instrumentation packages
+
+Detect the project's package manager first: the `packageManager` field in package.json
+is authoritative when present; otherwise the lockfile decides — `pnpm-lock.yaml` →
+pnpm, `yarn.lock` → yarn, `bun.lock` → bun, `package-lock.json` → npm. Run every
+install with that manager — a second manager writes a second lockfile and diverges
+silently. The `npx @kopai/cli` validation commands are manager-neutral; npx ships with
+Node and never touches the project's dependency tree.
+
+Check deprecation against the registry, not install output — only npm prints full
+deprecation warnings at install time; pnpm truncates them and Yarn 4 prints none at
+all. When npm does print them, read them: never filter an install through `tail`,
+`grep -v`, or `--quiet`.
+
+```bash
+npm view @opentelemetry/instrumentation-<lib> deprecated   # empty output = not deprecated
+```
+
+`npm view` is a pure registry read that works inside pnpm/yarn projects too (npm ships
+with Node); native equivalents are `pnpm view <pkg> deprecated` and
+`yarn npm info <pkg> --fields deprecated --json` (Yarn 4).
+
+A deprecation message usually names its replacement — use it, never the deprecated
+package; when none is named, follow the package's own migration guidance instead of
+guessing. When a framework team ships its own plugin (Fastify → `@fastify/otel`), prefer
+it over the contrib package: it registers through the framework's plugin system instead
+of intercepting `require`/`import` — interception that native-ESM imports bypass unless
+an experimental loader hook is added.
+
 ## Rules
 
 Task-scoped rule files. Load one only when the workflow points at it.
 
 **Setup** — [setup-backend](references/setup-backend.md), [setup-environment](references/setup-environment.md)
 
-**Language SDKs** — [lang-nodejs](references/lang-nodejs.md), [lang-nextjs](references/lang-nextjs.md),
+**Language SDKs** — [lang-nodejs](references/lang-nodejs.md), [lang-fastify](references/lang-fastify.md),
+[lang-nextjs](references/lang-nextjs.md),
 [lang-python](references/lang-python.md), [lang-go](references/lang-go.md),
 [lang-java](references/lang-java.md), [lang-dotnet](references/lang-dotnet.md),
 [lang-ruby](references/lang-ruby.md), [lang-php](references/lang-php.md),

--- a/skills/otel-instrumentation/references/_sections.md
+++ b/skills/otel-instrumentation/references/_sections.md
@@ -7,10 +7,10 @@
 File inventory for the OpenTelemetry instrumentation rules. `SKILL.md` routes by task;
 this table is the complete list.
 
-| Section      | Impact   | Files                                                                                                                                                          |
-| ------------ | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| setup        | CRITICAL | setup-backend.md, setup-environment.md                                                                                                                         |
-| lang         | HIGH     | lang-nodejs.md, lang-nextjs.md, lang-python.md, lang-go.md, lang-java.md, lang-dotnet.md, lang-ruby.md, lang-php.md, lang-rust.md, lang-erlang.md, lang-cpp.md |
-| instrument   | CRITICAL | instrument-spans.md, instrument-attributes.md, instrument-errors.md, context-propagation.md, layered-telemetry.md, sampling.md                                 |
-| validate     | CRITICAL | drive-traffic.md, validate-traces.md, validate-logs.md, validate-metrics.md, validate-shutdown.md                                                              |
-| troubleshoot | HIGH     | troubleshoot-no-data.md, troubleshoot-missing-spans.md, troubleshoot-missing-attrs.md, troubleshoot-wrong-port.md                                              |
+| Section      | Impact   | Files                                                                                                                                                                           |
+| ------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| setup        | CRITICAL | setup-backend.md, setup-environment.md                                                                                                                                          |
+| lang         | HIGH     | lang-nodejs.md, lang-fastify.md, lang-nextjs.md, lang-python.md, lang-go.md, lang-java.md, lang-dotnet.md, lang-ruby.md, lang-php.md, lang-rust.md, lang-erlang.md, lang-cpp.md |
+| instrument   | CRITICAL | instrument-spans.md, instrument-attributes.md, instrument-errors.md, context-propagation.md, layered-telemetry.md, sampling.md                                                  |
+| validate     | CRITICAL | drive-traffic.md, validate-traces.md, validate-logs.md, validate-metrics.md, validate-shutdown.md                                                                               |
+| troubleshoot | HIGH     | troubleshoot-no-data.md, troubleshoot-missing-spans.md, troubleshoot-missing-attrs.md, troubleshoot-wrong-port.md                                                               |

--- a/skills/otel-instrumentation/references/context-propagation.md
+++ b/skills/otel-instrumentation/references/context-propagation.md
@@ -94,7 +94,7 @@ phases, because the failure modes compound and become hard to attribute.
 ```bash
 # orphans by name — anything that isn't an entry point is a bug
 npx @kopai/cli traces search --resource-attr "validation.run_id=$RUN_ID" --json \
-  | jq -r '.[] | select((.parentSpanId // "") == "") | .name' | sort | uniq -c | sort -rn
+  | jq -r '.[] | select((.ParentSpanId // "") == "") | .SpanName' | sort | uniq -c | sort -rn
 ```
 
 A database, cache, or HTTP-client span appearing as an orphan means context isn't

--- a/skills/otel-instrumentation/references/custom-instrumentation.md
+++ b/skills/otel-instrumentation/references/custom-instrumentation.md
@@ -371,7 +371,7 @@ slugs — that distinction is the whole value.
 ```bash
 npx @kopai/cli traces search --resource-attr "validation.run_id=$RUN_ID" \
   --status-code ERROR --json \
-  | jq -r '.[] | select(.attributes["exception.slug"] == null) | .name' | sort -u
+  | jq -r '.[] | select(.SpanAttributes["exception.slug"] == null) | .SpanName' | sort -u
 ```
 
 ---

--- a/skills/otel-instrumentation/references/instrument-errors.md
+++ b/skills/otel-instrumentation/references/instrument-errors.md
@@ -104,7 +104,7 @@ npx @kopai/cli traces search --resource-attr "validation.run_id=$RUN_ID" \
 # and every one of them carries a slug
 npx @kopai/cli traces search --resource-attr "validation.run_id=$RUN_ID" \
   --status-code ERROR --json \
-  | jq -r '.[] | [.name, (.attributes["exception.slug"] // "NO-SLUG")] | @tsv'
+  | jq -r '.[] | [.SpanName, (.SpanAttributes["exception.slug"] // "NO-SLUG")] | @tsv'
 ```
 
 Zero rows from the first command does not mean no errors — you drove them on purpose.

--- a/skills/otel-instrumentation/references/lang-fastify.md
+++ b/skills/otel-instrumentation/references/lang-fastify.md
@@ -1,0 +1,171 @@
+| title                   | impact | tags                                       |
+| ----------------------- | ------ | ------------------------------------------ |
+| Fastify Instrumentation | HIGH   | lang, nodejs, fastify, traces, esm, plugin |
+
+# Fastify Instrumentation
+
+Instrument Fastify with **`@fastify/otel`** — the plugin maintained by the Fastify
+team — registered explicitly through `app.register(...)`, plus the Node SDK for
+everything below the framework (HTTP server, DB clients, fetch).
+
+## The one rule
+
+Never install `@opentelemetry/instrumentation-fastify`. It was deprecated in January
+2025 in favor of `@fastify/otel` and removed from `auto-instrumentations-node` in
+March 2026. It relies on module interception, which is where silent failures live: a
+dependency loaded through a path the hooks don't cover — native ESM being the common
+case — leaves the SDK loaded, printing no error, instrumenting nothing.
+`@fastify/otel` hooks routes through Fastify's own plugin system, so loader semantics
+never enter the picture.
+
+If the codebase already depends on `@opentelemetry/instrumentation-fastify`, migrate to
+this recipe — do not work around it. Two gates: `@fastify/otel` supports Fastify
+`>=4 <6` (a Fastify 3 app must upgrade the framework first; the contrib package was the
+only option there and is unmaintained), and the OTel packages below require Node.js
+`^18.19.0 || >=20.6.0` — the same floor `node --import` needs.
+
+## Install
+
+```bash
+npm install @fastify/otel @opentelemetry/api @opentelemetry/sdk-node @opentelemetry/auto-instrumentations-node
+```
+
+npm shown — install with the project's own package manager (`pnpm add` / `yarn add`),
+detected per the package-picking rule in SKILL.md.
+
+`@fastify/otel` handles the framework layer and stands alone if it must: it extracts
+incoming trace context itself and emits a SERVER-kind `request` span when no HTTP
+instrumentation is active. Keep `@opentelemetry/instrumentation-http` (bundled in the
+auto-instrumentations) anyway — it adds the protocol-level server span (the Fastify
+span then nests under it as INTERNAL), propagation on outgoing requests to downstream
+services, and the rest of the auto-instrumentation coverage.
+
+## Instrumentation file (instrumentation.mjs)
+
+Create the Fastify instrumentation here and **export it** so the app can register its
+plugin:
+
+```javascript
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import { getNodeAutoInstrumentations } from "@opentelemetry/auto-instrumentations-node";
+import FastifyOtelInstrumentation from "@fastify/otel";
+
+export const fastifyOtel = new FastifyOtelInstrumentation();
+
+const sdk = new NodeSDK({
+  instrumentations: [getNodeAutoInstrumentations(), fastifyOtel],
+});
+
+sdk.start();
+
+// Graceful shutdown
+process.on("SIGTERM", () => {
+  sdk
+    .shutdown()
+    .then(() => console.log("Tracing terminated"))
+    .catch((error) => console.log("Error terminating tracing", error))
+    .finally(() => process.exit(0));
+});
+```
+
+## Register the plugin (server.mjs)
+
+`await` the registration, and do it **before any route or hook definition** — the
+plugin has to see every route being registered:
+
+```javascript
+import Fastify from "fastify";
+import { fastifyOtel } from "./instrumentation.mjs";
+
+const app = Fastify();
+
+await app.register(fastifyOtel.plugin()); // first registration, always awaited
+
+app.get("/", async () => ({ hello: "world" }));
+
+// Skip telemetry for noise routes
+app.get("/healthcheck", { config: { otel: false } }, async () => "Up!");
+
+await app.listen({ port: 3000 });
+```
+
+## Run
+
+```bash
+node --import ./instrumentation.mjs server.mjs
+```
+
+`server.mjs` already imports the instrumentation file, but keep `--import` anyway: it
+guarantees the SDK starts before anything else `server.mjs` pulls in.
+
+Know what patches without further help in a `"type": "module"` app: CommonJS
+dependencies — Fastify itself and most database drivers — still load through the
+`require` hook and patch fine. Dependencies published as **native ESM** bypass that
+hook. If the validate step shows their client spans missing, add OTel's ESM loader
+hook:
+
+```bash
+node --experimental-loader=@opentelemetry/instrumentation/hook.mjs \
+  --import ./instrumentation.mjs server.mjs
+```
+
+The hook is experimental and wraps every import — add it when validation shows the gap,
+not by default. The Fastify layer needs none of this; the plugin registers through
+Fastify itself.
+
+## registerOnInitialization — one mode, never both
+
+`new FastifyOtelInstrumentation({ registerOnInitialization: true })` auto-registers the
+plugin on every Fastify instance created after `sdk.start()`. No module interception is
+involved — `@fastify/otel` does none at all — it subscribes to Fastify's
+`fastify.initialization` diagnostics channel. A valid alternative, with two conditions
+this recipe prefers not to depend on: the SDK must be enabled before any Fastify
+instance exists, and the running Fastify version must publish that channel. Explicit
+`app.register(fastifyOtel.plugin())` costs one line, is visible in app code, and cannot
+miss.
+
+Pick exactly one mode. With the flag on, also registering the plugin manually decorates
+the same instance twice and Fastify throws (decoration already present).
+
+## What gets instrumented
+
+| Layer                     | Package                               | Spans                                                |
+| ------------------------- | ------------------------------------- | ---------------------------------------------------- |
+| HTTP server               | `@opentelemetry/instrumentation-http` | Root span per request, incoming context extraction   |
+| Fastify framework         | `@fastify/otel`                       | Request/handler spans, hook spans, sets `http.route` |
+| Downstream (db, fetch, …) | auto-instrumentations-node            | Client spans as children of the handler              |
+
+## Validate
+
+The generic loop applies unchanged, but add one Fastify-specific assertion: spans from
+the `@fastify/otel` instrumentation scope exist. HTTP-layer-only telemetry is exactly
+what a failed plugin registration produces, and it looks healthy until you group by
+scope:
+
+```bash
+npx @kopai/cli traces search --scope "@fastify/otel" \
+  --resource-attr "validation.run_id=$RUN_ID" --json | jq 'length'
+```
+
+**Pass:** greater than zero — the plugin's `request` and handler spans are flowing,
+with `http.route` in `SpanAttributes`.
+**Fail:** zero while generic HTTP spans exist = the plugin never registered. Check that
+`app.register(fastifyOtel.plugin())` runs before any route definition and is awaited.
+
+## Reference
+
+- [@fastify/otel](https://github.com/fastify/otel)
+
+## Next
+
+SDK setup is step 3 of six. It gets bytes flowing; it does not make the telemetry good.
+
+1. Decide what earns a span — `instrument-spans.md`
+2. Add the context that makes spans answerable — `instrument-attributes.md`
+3. Instrument the error paths — `instrument-errors.md`
+4. Drive traffic yourself — `drive-traffic.md`
+5. Assert on what arrived — `validate-traces.md`
+
+Confirm before moving on: the SDK starts **before** any application code that could
+create a span, and shutdown flushes on SIGTERM (`validate-shutdown.md`). Both fail
+silently.

--- a/skills/otel-instrumentation/references/lang-nodejs.md
+++ b/skills/otel-instrumentation/references/lang-nodejs.md
@@ -12,13 +12,17 @@ Set up OpenTelemetry SDK for Node.js applications with automatic instrumentation
 npm install @opentelemetry/sdk-node @opentelemetry/auto-instrumentations-node @opentelemetry/api
 ```
 
+npm shown — install with the project's own package manager (`pnpm add` / `yarn add`),
+detected per the package-picking rule in SKILL.md.
+
 ## Configuration
 
 **Environment Variables:**
-| Variable | Description |
-|----------|-------------|
+
+| Variable                      | Description                                   |
+| ----------------------------- | --------------------------------------------- |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP endpoint (e.g., `http://localhost:4318`) |
-| `OTEL_SERVICE_NAME` | Service name shown in observability backend |
+| `OTEL_SERVICE_NAME`           | Service name shown in observability backend   |
 
 ## Instrumentation File (instrumentation.mjs)
 
@@ -62,6 +66,15 @@ Or in package.json:
 }
 ```
 
+In a `"type": "module"` app this patches CommonJS dependencies (they still load through
+the `require` hook). A dependency published as **native ESM** bypasses that hook and
+additionally needs OTel's experimental loader hook:
+
+```bash
+node --experimental-loader=@opentelemetry/instrumentation/hook.mjs \
+  --import ./instrumentation.mjs server.mjs
+```
+
 ## What Gets Instrumented
 
 The auto-instrumentation automatically captures:
@@ -71,6 +84,14 @@ The auto-instrumentation automatically captures:
 - **Metrics**: HTTP request metrics (with additional config)
 
 The SDK auto-detects `OTEL_EXPORTER_OTLP_ENDPOINT` and exports via OTLP HTTP.
+
+## Framework coverage
+
+`getNodeAutoInstrumentations()` covers Express, Koa, Hapi, and most HTTP/DB clients. It
+does **not** cover Fastify — that instrumentation moved to the Fastify team
+(`@fastify/otel`) and the deprecated contrib package was removed from the bundle in
+March 2026. Fastify app → `lang-fastify.md`, which registers a plugin instead of
+relying on module interception.
 
 ## Example
 

--- a/skills/otel-instrumentation/references/troubleshoot-missing-attrs.md
+++ b/skills/otel-instrumentation/references/troubleshoot-missing-attrs.md
@@ -8,7 +8,7 @@ Spans arrive, but they're too narrow to answer anything. First, see what you act
 
 ```bash
 npx @kopai/cli traces search --resource-attr "validation.run_id=$RUN_ID" --json \
-  | jq -r '.[].attributes // {} | keys[]' | sort -u
+  | jq -r '.[].SpanAttributes // {} | keys[]' | sort -u
 ```
 
 Diff that against [references/attributes.md](../references/attributes.md).

--- a/skills/otel-instrumentation/references/troubleshoot-missing-spans.md
+++ b/skills/otel-instrumentation/references/troubleshoot-missing-spans.md
@@ -15,7 +15,7 @@ code runs perfectly the entire time it's happening.
 
 ```bash
 npx @kopai/cli traces search --resource-attr "validation.run_id=$RUN_ID" --json \
-  | jq -r '.[] | select((.parentSpanId // "") == "") | .name' | sort | uniq -c | sort -rn
+  | jq -r '.[] | select((.ParentSpanId // "") == "") | .SpanName' | sort | uniq -c | sort -rn
 ```
 
 Every name here that isn't an entry point is a break. Go to `context-propagation.md` —
@@ -69,6 +69,27 @@ full, which looks exactly like sampling.
 Initialisation ordering. The SDK must start _before_ the libraries it patches are
 imported. In Node.js this means `--import`/`--require`, not a `require()` at the top of
 `server.mjs` — by then the modules are already loaded and unpatchable.
+
+Two more causes with the identical symptom — patching that no-ops without an error:
+
+- **Native-ESM dependencies.** `"type": "module"` doesn't disable patching wholesale:
+  CommonJS dependencies still load through the `require` hook and patch fine. A
+  dependency published as native ESM bypasses that hook and needs OTel's loader hook
+  registered before the app loads:
+  `--experimental-loader=@opentelemetry/instrumentation/hook.mjs`. Diagnose per
+  dependency, by its packaging — and if the framework ships a native plugin, prefer it
+  over loader mechanics entirely (Fastify → `lang-fastify.md`).
+- **A deprecated instrumentation package.** Deprecation doesn't disable the code — it
+  means unmaintained and superseded, so it silently falls behind the framework versions
+  and loader semantics it once patched. Check the version actually installed —
+  `npm ls <pkg>` (`pnpm list <pkg>` / `yarn why <pkg>`) — then
+  `npm view <pkg>@<version> deprecated`; a bare `npm view <pkg> deprecated` reads the
+  latest release, which may differ. `npm view` works in any project regardless of its
+  package manager — it is a registry read, and npm ships with Node. The message
+  is free text: it usually names the replacement; when it doesn't, check the package's
+  migration notes. Either way, spend the time migrating (after a compatibility check),
+  not debugging the abandoned package. Known case:
+  `@opentelemetry/instrumentation-fastify` → `@fastify/otel`.
 
 ## Then
 

--- a/skills/otel-instrumentation/references/validate-logs.md
+++ b/skills/otel-instrumentation/references/validate-logs.md
@@ -28,7 +28,7 @@ Take a trace ID from the run and ask for its logs:
 
 ```bash
 TRACE_ID=$(npx @kopai/cli traces search --resource-attr "validation.run_id=$RUN_ID" \
-  --limit 1 --json | jq -r '.[0].traceId')
+  --limit 1 --json | jq -r '.[0].TraceId')
 
 npx @kopai/cli logs search --trace-id "$TRACE_ID" --json | jq 'length'
 ```
@@ -57,7 +57,7 @@ for real problems.
 
 ```bash
 npx @kopai/cli logs search --service "$OTEL_SERVICE_NAME" --severity-text ERROR --json \
-  | jq -r '.[] | .body' | head -20
+  | jq -r '.[] | .Body' | head -20
 ```
 
 **Pass:** each body identifies the operation and the reason. Structured fields beat

--- a/skills/otel-instrumentation/references/validate-traces.md
+++ b/skills/otel-instrumentation/references/validate-traces.md
@@ -19,9 +19,10 @@ know the real field names:
 npx @kopai/cli traces search --resource-attr "validation.run_id=$RUN_ID" --limit 1 --json | jq .
 ```
 
-The assertions below use OTLP/JSON names — `name`, `traceId`, `spanId`, `parentSpanId`,
-`attributes`, `resource`, `status`. **If the output uses different names, substitute
-them** in every `jq` filter that follows. Do this once, at the top of the loop.
+The assertions below use the current CLI's row names — `SpanName`, `TraceId`, `SpanId`,
+`ParentSpanId`, `SpanAttributes`, `ResourceAttributes`, `StatusCode`. **If the output
+uses different names, substitute them** in every `jq` filter that follows. Do this
+once, at the top of the loop.
 
 For assertions richer than `jq` can express comfortably, escalate to `@kopai/sdk` code
 mode — the typed query API, `kq`, and `client.query()` are documented in the
@@ -54,7 +55,7 @@ downstream of one is a context-propagation bug.
 
 ```bash
 npx @kopai/cli traces search --resource-attr "validation.run_id=$RUN_ID" --json \
-  | jq '[.[] | select((.parentSpanId // "") == "")] | length as $orphans
+  | jq '[.[] | select((.ParentSpanId // "") == "")] | length as $orphans
         | "orphans: \($orphans)"'
 ```
 
@@ -67,7 +68,7 @@ List the orphans by name to see which ones shouldn't be:
 
 ```bash
 npx @kopai/cli traces search --resource-attr "validation.run_id=$RUN_ID" --json \
-  | jq -r '.[] | select((.parentSpanId // "") == "") | .name' | sort | uniq -c | sort -rn
+  | jq -r '.[] | select((.ParentSpanId // "") == "") | .SpanName' | sort | uniq -c | sort -rn
 ```
 
 A database or HTTP-client span in that list is always a bug.
@@ -76,7 +77,7 @@ A database or HTTP-client span in that list is always a bug.
 
 ```bash
 npx @kopai/cli traces search --resource-attr "validation.run_id=$RUN_ID" --json \
-  | jq -r 'group_by(.traceId) | map(length)
+  | jq -r 'group_by(.TraceId) | map(length)
            | "traces: \(length), spans per trace: min \(min) max \(max)"'
 ```
 
@@ -89,7 +90,7 @@ package for each library is installed, then `context-propagation.md`.
 
 ```bash
 npx @kopai/cli traces search --resource-attr "validation.run_id=$RUN_ID" --json \
-  | jq -r '.[].name' | sort -u
+  | jq -r '.[].SpanName' | sort -u
 ```
 
 **Pass:** every entry point from your route sweep appears. Compare against the list you
@@ -128,7 +129,7 @@ Then check those failures carry a **slug**:
 ```bash
 npx @kopai/cli traces search --resource-attr "validation.run_id=$RUN_ID" \
   --status-code ERROR --json \
-  | jq -r '.[] | [.name, (.attributes["exception.slug"] // "NO-SLUG")] | @tsv'
+  | jq -r '.[] | [.SpanName, (.SpanAttributes["exception.slug"] // "NO-SLUG")] | @tsv'
 ```
 
 **Pass:** no `NO-SLUG` rows — every failure site is greppable and groupable.
@@ -140,7 +141,7 @@ List every attribute key this run produced:
 
 ```bash
 npx @kopai/cli traces search --resource-attr "validation.run_id=$RUN_ID" --json \
-  | jq -r '.[].attributes // {} | keys[]' | sort -u
+  | jq -r '.[].SpanAttributes // {} | keys[]' | sort -u
 ```
 
 Diff that against [references/attributes.md](../references/attributes.md).
@@ -155,7 +156,7 @@ slow paths). Missing any one of them means the next incident stalls.
 
 ```bash
 npx @kopai/cli traces search --resource-attr "validation.run_id=$RUN_ID" --json \
-  | jq -r '.[].name' | grep -iE 'test|debug|foo|bar|tmp|xxx' || echo "clean"
+  | jq -r '.[].SpanName' | grep -iE 'test|debug|foo|bar|tmp|xxx' || echo "clean"
 ```
 
 **Pass:** `clean`. A span created only to prove tracing worked is an artefact — delete it

--- a/skills/otel-instrumentation/tile.json
+++ b/skills/otel-instrumentation/tile.json
@@ -1,6 +1,6 @@
 {
   "name": "kopai/otel-instrumentation",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": false,
   "summary": "Instrument applications with the OpenTelemetry SDK and prove the telemetry is good by validating it against a local Kopai backend. Use when setting up observability, adding tracing/logging/metrics, deciding what to instrument or which attributes to add, retrofitting OTel into an existing codebase, threading context through call chains, configuring sampling, or when traces/logs/metrics aren't appearing after setup. Also use when users say things like \"my traces aren't showing up\", \"I don't see any data\", or \"how do I add observability to my app\". Do NOT use to investigate existing telemetry for a root cause (use root-cause-analysis), to build dashboards (use create-dashboard), or to instrument LLM and agent calls (use otel-genai-instrumentation).",
   "skills": {


### PR DESCRIPTION
This updates our OpenTelemetry instrumentation guide (the skill) to version 2.1.0.

**What went wrong that this fixes**

We tested the skill on a Fastify app (Fastify is a popular Node.js web server). The AI following it made two mistakes:

- It installed a tracing package that has been abandoned. npm printed a warning during install saying "use @fastify/otel instead" — but the warning was cut off because the install output went through a filter. That abandoned package was fully removed from the standard auto-instrumentation bundle in March 2026. So today, the skill's generic Node.js instructions produce no Fastify tracing data at all, and no error either. It silently does nothing.
- The old package worked by intercepting code as it loads. In modern JavaScript apps (`"type": "module"`), that interception quietly fails.

**What's new**

A dedicated Fastify page, references/lang-fastify.md. It uses @fastify/otel — the tracing plugin the Fastify team itself maintains — wired up as a normal Fastify plugin with `app.register(...)`, so no load-time interception is involved. The page also covers:

- It works on Fastify 4 and 5 only. Fastify 3 apps must upgrade the framework first.
- Which packages still get traced automatically in modern apps: old-style CommonJS packages do. Packages shipped as native ESM need one extra startup flag (`--experimental-loader=@opentelemetry/instrumentation/hook.mjs`) — and you only add it when the check below shows data missing.
- The plugin's auto-register option is legitimate (it listens for new Fastify servers via a built-in Node.js channel), but you must pick either auto-register or manual registration. Doing both crashes the app.
- A check that proves the Fastify plugin is actually reporting: search for data tagged with the `@fastify/otel` source (`--scope "@fastify/otel"`). Without it, everything looks healthy even when the plugin never started.

**A new general rule in the skill**

The root cause was ignoring the installer's warning. The main guide now says: never filter install output, ask npm directly whether a package is abandoned before using it (`npm view <pkg> deprecated`), and prefer plugins built by the framework's own team.

**Bug fix in the existing verification commands**

The skill's check commands read fields named `name`, `traceId`, `parentSpanId` from our CLI's output — but the CLI actually outputs `SpanName`, `TraceId`, `ParentSpanId`, `SpanAttributes`, `Body`. Wrong names return nothing, and the "orphaned spans" check flagged every single span as broken. All field names now match the real output. Two things were deliberately left alone: the metrics command (it genuinely uses lowercase names) and the "calibrate once" note telling readers to double-check names against their own output.

**How this was checked**

Every claim was verified against the @fastify/otel source code (version 0.20.1), the official OpenTelemetry docs, the npm registry, and our own CLI code. The whole change then went through an adversarial review — two independent codex reviews plus a verification pass. They found 9 real problems. All 9 are fixed in this PR.

Merging auto-publishes version 2.1.0 via the Tessl workflow.