### PR TITLE
fix(ui): load trace search operations from the picked service

### DIFF
--- a/.changeset/trace-search-form-remount.md
+++ b/.changeset/trace-search-form-remount.md
@@ -1,0 +1,5 @@
+---
+"@kopai/ui": patch
+---
+
+Fixed the trace search form keeping filters from a previous search after browser back/forward. The form now rebuilds itself whenever the committed search changes, so a service can no longer be paired with an operation belonging to a different one. Filters carried in the URL — operation, tags, lookback, durations and limit — are also restored into the form on load, where previously only the service was and the rest were silently dropped on the next submit. The operation list now waits for the service picker to settle before fetching, instead of issuing a request per service arrowed past.

--- a/.changeset/trace-search-operation-picker.md
+++ b/.changeset/trace-search-operation-picker.md
@@ -1,0 +1,5 @@
+---
+"@kopai/ui": patch
+---
+
+Fixed the trace search operation picker staying empty until a search had already been run. Operations now load from the service selected in the form rather than the one in the URL, which only catches up on submit. Changing the service also clears any operation held over from the previous one, the picker is disabled until a service is chosen, and selecting "All Services" now actually clears the service filter instead of re-applying the current one.

--- a/packages/ui/src/components/observability/LogTimeline/LogFilter.tsx
+++ b/packages/ui/src/components/observability/LogTimeline/LogFilter.tsx
@@ -5,6 +5,7 @@
 
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import type { dataFilterSchemas, denormalizedSignals } from "@kopai/core";
+import { useDebouncedValue } from "../utils/use-debounced-value.js";
 
 type LogsDataFilter = dataFilterSchemas.LogsDataFilter;
 type OtelLogsRow = denormalizedSignals.OtelLogsRow;
@@ -94,19 +95,6 @@ const INPUT_CLS =
   "w-full bg-muted/50 border border-border rounded px-2 py-1.5 text-sm text-foreground placeholder:text-muted-foreground/50";
 
 const LABEL_CLS = "text-xs text-muted-foreground";
-
-// ---------------------------------------------------------------------------
-// Debounce hook
-// ---------------------------------------------------------------------------
-
-function useDebouncedValue<T>(value: T, delayMs: number): T {
-  const [debounced, setDebounced] = useState(value);
-  useEffect(() => {
-    const id = setTimeout(() => setDebounced(value), delayMs);
-    return () => clearTimeout(id);
-  }, [value, delayMs]);
-  return debounced;
-}
 
 // ---------------------------------------------------------------------------
 // MultiSelect dropdown

--- a/packages/ui/src/components/observability/TraceSearch/SearchForm.tsx
+++ b/packages/ui/src/components/observability/TraceSearch/SearchForm.tsx
@@ -20,6 +20,12 @@ export interface SearchFormProps {
   operations: string[];
   initialValues?: Partial<SearchFormValues>;
   onSubmit: (values: SearchFormValues) => void;
+  /**
+   * Fires as soon as the service picker changes, before submit — the parent
+   * needs it to load that service's operations while the form is still being
+   * filled in.
+   */
+  onServiceChange?: (service: string) => void;
   isLoading?: boolean;
 }
 
@@ -42,6 +48,7 @@ export function SearchForm({
   operations,
   initialValues,
   onSubmit,
+  onServiceChange,
   isLoading,
 }: SearchFormProps) {
   const [service, setService] = useState(initialValues?.service ?? "");
@@ -60,6 +67,14 @@ export function SearchForm({
   useEffect(() => {
     if (initialValues?.service != null) setService(initialValues.service);
   }, [initialValues?.service]);
+
+  const handleServiceChange = (next: string) => {
+    setService(next);
+    // The operation list is scoped to the service, so a held-over operation
+    // would filter on a name the new service never emits.
+    setOperation("");
+    onServiceChange?.(next);
+  };
 
   const handleSubmit = () => {
     onSubmit({
@@ -84,7 +99,7 @@ export function SearchForm({
         <span className="text-xs text-muted-foreground">Service</span>
         <select
           value={service}
-          onChange={(e) => setService(e.target.value)}
+          onChange={(e) => handleServiceChange(e.target.value)}
           className={inputClass}
         >
           <option value="">All Services</option>
@@ -102,9 +117,12 @@ export function SearchForm({
         <select
           value={operation}
           onChange={(e) => setOperation(e.target.value)}
-          className={inputClass}
+          disabled={!service}
+          className={`${inputClass} disabled:opacity-50`}
         >
-          <option value="">All Operations</option>
+          <option value="">
+            {service ? "All Operations" : "Select a service first"}
+          </option>
           {operations.map((op) => (
             <option key={op} value={op}>
               {op}

--- a/packages/ui/src/components/observability/TraceSearch/SearchForm.tsx
+++ b/packages/ui/src/components/observability/TraceSearch/SearchForm.tsx
@@ -1,9 +1,14 @@
 /**
  * SearchForm - Jaeger-style sidebar search form for trace filtering.
- * Owns its own form state; parent only receives values on submit.
+ *
+ * Owns its own form state; the parent only receives values on submit. The
+ * parent must remount it (`key={filtersKey(...)}`) whenever the committed
+ * search changes, which is how the draft is reset on submit and on browser
+ * back/forward. Syncing a field in from props instead would give that field a
+ * second writer that bypasses the clearing rules in the change handlers.
  */
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 
 export interface SearchFormValues {
   service: string;
@@ -13,6 +18,22 @@ export interface SearchFormValues {
   minDuration: string;
   maxDuration: string;
   limit: number;
+}
+
+/**
+ * Identity of a committed search — feed it to `key` to rebuild the form from
+ * `initialValues` when, and only when, the committed search changes.
+ */
+export function filtersKey(values: SearchFormValues): string {
+  return JSON.stringify([
+    values.service,
+    values.operation,
+    values.tags,
+    values.lookback,
+    values.minDuration,
+    values.maxDuration,
+    values.limit,
+  ]);
 }
 
 export interface SearchFormProps {
@@ -62,11 +83,6 @@ export function SearchForm({
     initialValues?.maxDuration ?? ""
   );
   const [limit, setLimit] = useState(initialValues?.limit ?? 20);
-
-  // Sync service from URL-driven changes
-  useEffect(() => {
-    if (initialValues?.service != null) setService(initialValues.service);
-  }, [initialValues?.service]);
 
   const handleServiceChange = (next: string) => {
     setService(next);

--- a/packages/ui/src/components/observability/TraceSearch/TraceSearch.stories.tsx
+++ b/packages/ui/src/components/observability/TraceSearch/TraceSearch.stories.tsx
@@ -1,5 +1,7 @@
+import { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { TraceSearch } from "./index.js";
+import type { SearchFormValues } from "./SearchForm.js";
 import { mockTraceSummaries } from "../__fixtures__/trace-summaries.js";
 
 const meta: Meta<typeof TraceSearch> = {
@@ -9,41 +11,68 @@ const meta: Meta<typeof TraceSearch> = {
 export default meta;
 type Story = StoryObj<typeof TraceSearch>;
 
+const BASE_FILTERS: SearchFormValues = {
+  service: "api-gateway",
+  operation: "",
+  tags: "",
+  lookback: "",
+  minDuration: "",
+  maxDuration: "",
+  limit: 20,
+};
+
+const OPERATIONS_BY_SERVICE: Record<string, string[]> = {
+  "api-gateway": [
+    "GET /api/users",
+    "POST /api/users",
+    "GET /api/products",
+    "PUT /api/users/42",
+    "DELETE /api/sessions",
+  ],
+  checkout: ["POST /checkout", "POST /checkout/pay"],
+};
+
 export const Default: Story = {
   args: {
-    service: "api-gateway",
+    initialFilters: BASE_FILTERS,
     traces: mockTraceSummaries,
-    operations: [
-      "GET /api/users",
-      "POST /api/users",
-      "GET /api/products",
-      "PUT /api/users/42",
-      "DELETE /api/sessions",
-    ],
+    operations: OPERATIONS_BY_SERVICE["api-gateway"],
   },
 };
 
 export const Loading: Story = {
-  args: { service: "api-gateway", traces: [], isLoading: true },
+  args: { initialFilters: BASE_FILTERS, traces: [], isLoading: true },
 };
 
 export const Error: Story = {
   args: {
-    service: "api-gateway",
+    initialFilters: BASE_FILTERS,
     traces: [],
     error: new globalThis.Error("Failed to fetch traces"),
   },
 };
 
 export const Empty: Story = {
-  args: { service: "api-gateway", traces: [] },
+  args: { initialFilters: BASE_FILTERS, traces: [] },
 };
 
+/**
+ * The operation picker is scoped to the selected service: it stays disabled
+ * until one is chosen, and its options reload on every service change.
+ */
 export const WithFilters: Story = {
-  args: {
-    service: "api-gateway",
-    traces: mockTraceSummaries,
-    operations: ["GET /api/users", "POST /api/users"],
-    onSearch: (filters) => console.log("Search:", filters),
+  render: () => {
+    const [service, setService] = useState(BASE_FILTERS.service);
+    return (
+      <TraceSearch
+        services={Object.keys(OPERATIONS_BY_SERVICE)}
+        initialFilters={BASE_FILTERS}
+        operations={OPERATIONS_BY_SERVICE[service] ?? []}
+        traces={mockTraceSummaries}
+        onSelectTrace={(traceId) => console.log("Select trace:", traceId)}
+        onSearch={(filters) => console.log("Search:", filters)}
+        onServiceChange={setService}
+      />
+    );
   },
 };

--- a/packages/ui/src/components/observability/TraceSearch/index.tsx
+++ b/packages/ui/src/components/observability/TraceSearch/index.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo } from "react";
 import { formatTimestamp } from "../utils/time.js";
 import { getServiceColor } from "../utils/colors.js";
-import { SearchForm } from "./SearchForm.js";
+import { SearchForm, filtersKey } from "./SearchForm.js";
 import type { SearchFormValues } from "./SearchForm.js";
 import { ScatterPlot } from "./ScatterPlot.js";
 import { SortDropdown } from "./SortDropdown.js";
@@ -36,7 +36,12 @@ export interface TraceSearchFilters {
 export interface TraceSearchProps {
   // Search form data
   services?: string[];
-  service: string;
+  /**
+   * The committed search, i.e. what the URL currently describes. Seeds the form
+   * and, on change, rebuilds it — so a submit or a back/forward can never leave
+   * one field showing a value that belongs to a different search.
+   */
+  initialFilters?: SearchFormValues;
   operations?: string[];
   // Results
   traces: TraceSummary[];
@@ -78,9 +83,19 @@ function sortTraces(traces: TraceSummary[], sort: string): TraceSummary[] {
 // Component
 // ---------------------------------------------------------------------------
 
+const EMPTY_FILTERS: SearchFormValues = {
+  service: "",
+  operation: "",
+  tags: "",
+  lookback: "",
+  minDuration: "",
+  maxDuration: "",
+  limit: 20,
+};
+
 export function TraceSearch({
   services = [],
-  service,
+  initialFilters = EMPTY_FILTERS,
   operations = [],
   traces,
   isLoading,
@@ -147,9 +162,10 @@ export function TraceSearch({
       {onSearch && (
         <div className="w-72 shrink-0 border border-border rounded-lg p-4 self-start">
           <SearchForm
+            key={filtersKey(initialFilters)}
             services={services}
             operations={operations}
-            initialValues={{ service }}
+            initialValues={initialFilters}
             onSubmit={handleFormSubmit}
             onServiceChange={onServiceChange}
             isLoading={isLoading}

--- a/packages/ui/src/components/observability/TraceSearch/index.tsx
+++ b/packages/ui/src/components/observability/TraceSearch/index.tsx
@@ -45,6 +45,8 @@ export interface TraceSearchProps {
   // Callbacks
   onSelectTrace: (traceId: string) => void;
   onSearch?: (filters: TraceSearchFilters) => void;
+  /** Fires on every service-picker change so the parent can load its operations. */
+  onServiceChange?: (service: string) => void;
   onCompare?: (traceIds: [string, string]) => void;
   // Sort
   sort?: string;
@@ -85,6 +87,7 @@ export function TraceSearch({
   error,
   onSelectTrace,
   onSearch,
+  onServiceChange,
   onCompare,
   sort: controlledSort,
   onSortChange,
@@ -148,6 +151,7 @@ export function TraceSearch({
             operations={operations}
             initialValues={{ service }}
             onSubmit={handleFormSubmit}
+            onServiceChange={onServiceChange}
             isLoading={isLoading}
           />
         </div>

--- a/packages/ui/src/components/observability/index.ts
+++ b/packages/ui/src/components/observability/index.ts
@@ -12,8 +12,11 @@ export type {
   TraceSummary,
 } from "./TraceSearch/index.js";
 
-export { SearchForm } from "./TraceSearch/SearchForm.js";
-export type { SearchFormProps } from "./TraceSearch/SearchForm.js";
+export { SearchForm, filtersKey } from "./TraceSearch/SearchForm.js";
+export type {
+  SearchFormProps,
+  SearchFormValues,
+} from "./TraceSearch/SearchForm.js";
 
 export { ScatterPlot } from "./TraceSearch/ScatterPlot.js";
 export type { ScatterPlotProps } from "./TraceSearch/ScatterPlot.js";

--- a/packages/ui/src/components/observability/renderers/OtelTraceDetail.tsx
+++ b/packages/ui/src/components/observability/renderers/OtelTraceDetail.tsx
@@ -85,7 +85,6 @@ function TraceSummariesView({
   return (
     <TraceSearch
       services={[]}
-      service=""
       traces={traces}
       isLoading={loading}
       error={error ?? undefined}

--- a/packages/ui/src/components/observability/utils/use-debounced-value.ts
+++ b/packages/ui/src/components/observability/utils/use-debounced-value.ts
@@ -1,0 +1,15 @@
+import { useState, useEffect } from "react";
+
+/**
+ * Returns `value` once it has stopped changing for `delayMs`. The first value
+ * is returned immediately, so an initial fetch is never delayed — only the
+ * churn from a user still choosing is.
+ */
+export function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(id);
+  }, [value, delayMs]);
+  return debounced;
+}

--- a/packages/ui/src/pages/observability.test.tsx
+++ b/packages/ui/src/pages/observability.test.tsx
@@ -66,31 +66,31 @@ const VALID_TREE = {
   },
 };
 
+let mockClient: MockClient;
+let originalLocation: string;
+
+beforeEach(() => {
+  mockClient = createMockClient();
+  queryClient.clear();
+  vi.clearAllMocks();
+  originalLocation = window.location.search;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  window.history.replaceState(
+    null,
+    "",
+    window.location.pathname + originalLocation
+  );
+});
+
+function setURL(params: string) {
+  window.history.replaceState(null, "", window.location.pathname + params);
+  window.dispatchEvent(new PopStateEvent("popstate"));
+}
+
 describe("useDashboardTree validation", () => {
-  let mockClient: MockClient;
-  let originalLocation: string;
-
-  beforeEach(() => {
-    mockClient = createMockClient();
-    queryClient.clear();
-    vi.clearAllMocks();
-    originalLocation = window.location.search;
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
-    window.history.replaceState(
-      null,
-      "",
-      window.location.pathname + originalLocation
-    );
-  });
-
-  function setURL(params: string) {
-    window.history.replaceState(null, "", window.location.pathname + params);
-    window.dispatchEvent(new PopStateEvent("popstate"));
-  }
-
   it("renders DynamicDashboard when API returns a valid uiTree", async () => {
     mockClient.getDashboard.mockResolvedValueOnce({ uiTree: VALID_TREE });
 
@@ -143,30 +143,6 @@ describe("useDashboardTree validation", () => {
 });
 
 describe("trace search operation picker", () => {
-  let mockClient: MockClient;
-  let originalLocation: string;
-
-  beforeEach(() => {
-    mockClient = createMockClient();
-    queryClient.clear();
-    vi.clearAllMocks();
-    originalLocation = window.location.search;
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
-    window.history.replaceState(
-      null,
-      "",
-      window.location.pathname + originalLocation
-    );
-  });
-
-  function setURL(params: string) {
-    window.history.replaceState(null, "", window.location.pathname + params);
-    window.dispatchEvent(new PopStateEvent("popstate"));
-  }
-
   it("loads the operations of a service as soon as it is picked, before any search is submitted", async () => {
     mockClient.getServices.mockResolvedValue({
       services: ["cart", "checkout"],
@@ -236,6 +212,166 @@ describe("trace search operation picker", () => {
     fireEvent.change(serviceSelect, { target: { value: "checkout" } });
 
     expect(operationSelect.value).toBe("");
+  });
+
+  it("does not submit an operation held over from a URL-driven service change", async () => {
+    mockClient.getServices.mockResolvedValue({
+      services: ["cart", "checkout"],
+    });
+    mockClient.getOperations.mockImplementation(async (serviceName: string) =>
+      serviceName === "cart"
+        ? { operations: ["GET /cart"] }
+        : { operations: ["POST /pay"] }
+    );
+
+    setURL("?tab=services&service=checkout");
+
+    render(
+      createElement(ObservabilityPage, {
+        client: mockClient as unknown as KopaiClient,
+      })
+    );
+
+    const operationSelect = (await screen.findByRole("combobox", {
+      name: /operation/i,
+    })) as HTMLSelectElement;
+    await waitFor(() => {
+      expect(screen.getByRole("option", { name: "POST /pay" })).toBeTruthy();
+    });
+    fireEvent.change(operationSelect, { target: { value: "POST /pay" } });
+    expect(operationSelect.value).toBe("POST /pay");
+
+    // Browser Back onto a search that ran against a different service.
+    setURL("?tab=services&service=cart");
+
+    await waitFor(() => {
+      const service = screen.getByRole("combobox", {
+        name: /service/i,
+      }) as HTMLSelectElement;
+      expect(service.value).toBe("cart");
+    });
+    await waitFor(() => {
+      expect(screen.getByRole("option", { name: "GET /cart" })).toBeTruthy();
+    });
+
+    // Submitting the committed search verbatim would rebuild the same URL and
+    // fire no request, leaving the assertions below on the pre-click call. Move
+    // one unrelated field so the submit is a genuinely new search.
+    fireEvent.change(screen.getByRole("spinbutton", { name: /limit/i }), {
+      target: { value: "50" },
+    });
+
+    const callsBefore = mockClient.searchTraceSummariesPage.mock.calls.length;
+    fireEvent.click(screen.getByRole("button", { name: /find traces/i }));
+
+    await waitFor(() => {
+      expect(
+        mockClient.searchTraceSummariesPage.mock.calls.length
+      ).toBeGreaterThan(callsBefore);
+    });
+
+    // "POST /pay" belongs to checkout — cart never emits it.
+    expect(window.location.search).toContain("service=cart");
+    expect(window.location.search).not.toContain("POST");
+    const lastCall = mockClient.searchTraceSummariesPage.mock.calls.at(-1);
+    expect(lastCall?.[0]).toMatchObject({ serviceName: "cart" });
+    expect(lastCall?.[0]).not.toHaveProperty("spanName");
+  });
+
+  it("hydrates the operation filter from the URL", async () => {
+    mockClient.getServices.mockResolvedValue({ services: ["cart"] });
+    mockClient.getOperations.mockResolvedValue({
+      operations: ["GET /cart"],
+    });
+
+    setURL("?tab=services&service=cart&operation=GET%20%2Fcart");
+
+    render(
+      createElement(ObservabilityPage, {
+        client: mockClient as unknown as KopaiClient,
+      })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("option", { name: "GET /cart" })).toBeTruthy();
+    });
+
+    const operationSelect = screen.getByRole("combobox", {
+      name: /operation/i,
+    }) as HTMLSelectElement;
+    expect(operationSelect.value).toBe("GET /cart");
+  });
+
+  it("hydrates the remaining trace filters from the URL", async () => {
+    mockClient.getServices.mockResolvedValue({ services: ["cart"] });
+
+    setURL(
+      "?tab=services&service=cart&tags=http.status_code%3D500" +
+        "&lookback=1h&minDuration=100ms&maxDuration=5s&limit=50"
+    );
+
+    render(
+      createElement(ObservabilityPage, {
+        client: mockClient as unknown as KopaiClient,
+      })
+    );
+
+    const tags = (await screen.findByRole("textbox", {
+      name: /tags/i,
+    })) as HTMLTextAreaElement;
+    expect(tags.value).toBe("http.status_code=500");
+
+    const lookback = screen.getByRole("combobox", {
+      name: /lookback/i,
+    }) as HTMLSelectElement;
+    expect(lookback.value).toBe("1h");
+
+    const minDuration = screen.getByRole("textbox", {
+      name: /min duration/i,
+    }) as HTMLInputElement;
+    expect(minDuration.value).toBe("100ms");
+
+    const maxDuration = screen.getByRole("textbox", {
+      name: /max duration/i,
+    }) as HTMLInputElement;
+    expect(maxDuration.value).toBe("5s");
+
+    const limit = screen.getByRole("spinbutton", {
+      name: /limit/i,
+    }) as HTMLInputElement;
+    expect(limit.value).toBe("50");
+  });
+
+  it("disables the operation picker until a service is chosen", async () => {
+    mockClient.getServices.mockResolvedValue({ services: ["cart"] });
+
+    setURL("?tab=services");
+
+    render(
+      createElement(ObservabilityPage, {
+        client: mockClient as unknown as KopaiClient,
+      })
+    );
+
+    const operationSelect = (await screen.findByRole("combobox", {
+      name: /operation/i,
+    })) as HTMLSelectElement;
+    expect(operationSelect.disabled).toBe(true);
+    expect(
+      screen.getByRole("option", { name: /select a service first/i })
+    ).toBeTruthy();
+
+    await waitFor(() => {
+      expect(screen.getByRole("option", { name: "cart" })).toBeTruthy();
+    });
+    fireEvent.change(screen.getByRole("combobox", { name: /service/i }), {
+      target: { value: "cart" },
+    });
+
+    const operationAfter = screen.getByRole("combobox", {
+      name: /operation/i,
+    }) as HTMLSelectElement;
+    expect(operationAfter.disabled).toBe(false);
   });
 
   it("clears the service filter when All Services is submitted", async () => {

--- a/packages/ui/src/pages/observability.test.tsx
+++ b/packages/ui/src/pages/observability.test.tsx
@@ -3,7 +3,7 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createElement } from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import ObservabilityPage from "./observability.js";
 import { queryClient } from "@kopai/ui-core";
 import type { KopaiClient } from "@kopai/sdk";
@@ -139,5 +139,134 @@ describe("useDashboardTree validation", () => {
       "def",
       expect.anything()
     );
+  });
+});
+
+describe("trace search operation picker", () => {
+  let mockClient: MockClient;
+  let originalLocation: string;
+
+  beforeEach(() => {
+    mockClient = createMockClient();
+    queryClient.clear();
+    vi.clearAllMocks();
+    originalLocation = window.location.search;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    window.history.replaceState(
+      null,
+      "",
+      window.location.pathname + originalLocation
+    );
+  });
+
+  function setURL(params: string) {
+    window.history.replaceState(null, "", window.location.pathname + params);
+    window.dispatchEvent(new PopStateEvent("popstate"));
+  }
+
+  it("loads the operations of a service as soon as it is picked, before any search is submitted", async () => {
+    mockClient.getServices.mockResolvedValue({
+      services: ["cart", "checkout"],
+    });
+    mockClient.getOperations.mockResolvedValue({
+      operations: ["GET /cart", "POST /cart"],
+    });
+
+    setURL("?tab=services");
+
+    render(
+      createElement(ObservabilityPage, {
+        client: mockClient as unknown as KopaiClient,
+      })
+    );
+
+    const serviceSelect = await screen.findByRole("combobox", {
+      name: /service/i,
+    });
+    await waitFor(() => {
+      expect(screen.getByRole("option", { name: "cart" })).toBeTruthy();
+    });
+
+    fireEvent.change(serviceSelect, { target: { value: "cart" } });
+
+    await waitFor(() => {
+      expect(mockClient.getOperations).toHaveBeenCalledWith(
+        "cart",
+        expect.anything()
+      );
+    });
+    await waitFor(() => {
+      expect(screen.getByRole("option", { name: "GET /cart" })).toBeTruthy();
+    });
+
+    // The URL is still untouched — no search was submitted.
+    expect(window.location.search).not.toContain("service=cart");
+  });
+
+  it("clears a stale operation when the service changes", async () => {
+    mockClient.getServices.mockResolvedValue({
+      services: ["cart", "checkout"],
+    });
+    mockClient.getOperations.mockResolvedValue({
+      operations: ["GET /cart"],
+    });
+
+    setURL("?tab=services&service=cart&operation=GET%20%2Fcart");
+
+    render(
+      createElement(ObservabilityPage, {
+        client: mockClient as unknown as KopaiClient,
+      })
+    );
+
+    const operationSelect = (await screen.findByRole("combobox", {
+      name: /operation/i,
+    })) as HTMLSelectElement;
+    const serviceSelect = screen.getByRole("combobox", { name: /service/i });
+
+    await waitFor(() => {
+      expect(screen.getByRole("option", { name: "GET /cart" })).toBeTruthy();
+    });
+    fireEvent.change(operationSelect, { target: { value: "GET /cart" } });
+    expect(operationSelect.value).toBe("GET /cart");
+
+    fireEvent.change(serviceSelect, { target: { value: "checkout" } });
+
+    expect(operationSelect.value).toBe("");
+  });
+
+  it("clears the service filter when All Services is submitted", async () => {
+    mockClient.getServices.mockResolvedValue({
+      services: ["cart", "checkout"],
+    });
+
+    setURL("?tab=services&service=cart");
+
+    render(
+      createElement(ObservabilityPage, {
+        client: mockClient as unknown as KopaiClient,
+      })
+    );
+
+    const serviceSelect = (await screen.findByRole("combobox", {
+      name: /service/i,
+    })) as HTMLSelectElement;
+    await waitFor(() => {
+      expect(serviceSelect.value).toBe("cart");
+    });
+
+    fireEvent.change(serviceSelect, { target: { value: "" } });
+    fireEvent.click(screen.getByRole("button", { name: /find traces/i }));
+
+    await waitFor(() => {
+      expect(window.location.search).not.toContain("service=");
+    });
+    await waitFor(() => {
+      const lastCall = mockClient.searchTraceSummariesPage.mock.calls.at(-1);
+      expect(lastCall?.[0]).not.toHaveProperty("serviceName");
+    });
   });
 });

--- a/packages/ui/src/pages/observability.tsx
+++ b/packages/ui/src/pages/observability.tsx
@@ -543,21 +543,21 @@ function TraceSearchView({
     urlState.tags,
   ]);
 
-  const handleSearch = useCallback(
-    (filters: TraceSearchFilters) => {
-      pushURLState({
-        tab: "services",
-        service: filters.service ?? service,
-        operation: filters.operation ?? null,
-        tags: filters.tags ?? null,
-        lookback: filters.lookback ?? null,
-        minDuration: filters.minDuration ?? null,
-        maxDuration: filters.maxDuration ?? null,
-        limit: filters.limit,
-      });
-    },
-    [service]
-  );
+  const handleSearch = useCallback((filters: TraceSearchFilters) => {
+    // The form submits every field, so an absent one means the user cleared it.
+    // Falling back to the URL's service here would make "All Services"
+    // unselectable — it would just re-apply whatever was already filtered.
+    pushURLState({
+      tab: "services",
+      service: filters.service ?? null,
+      operation: filters.operation ?? null,
+      tags: filters.tags ?? null,
+      lookback: filters.lookback ?? null,
+      minDuration: filters.minDuration ?? null,
+      maxDuration: filters.maxDuration ?? null,
+      limit: filters.limit,
+    });
+  }, []);
 
   // Fetch trace summaries
   const { data, loading, error } = useKopaiData<{
@@ -575,13 +575,23 @@ function TraceSearchView({
   );
   const _services = servicesData?.services ?? [];
 
-  // Fetch operations for selected service
+  // Operations follow the service picked in the form, not the one in the URL:
+  // the URL only catches up on submit, and the user needs the operation list
+  // before that to build the search.
+  const [pendingService, setPendingService] = useState(service ?? "");
+  useEffect(() => {
+    setPendingService(service ?? "");
+  }, [service]);
+
   const operationDs = useMemo<DataSource | undefined>(
     () =>
-      service
-        ? { method: "getOperations" as const, params: { serviceName: service } }
+      pendingService
+        ? {
+            method: "getOperations" as const,
+            params: { serviceName: pendingService },
+          }
         : undefined,
-    [service]
+    [pendingService]
   );
   const { data: opsData } = useKopaiData<{ operations: string[] }>(operationDs);
   const operations = opsData?.operations ?? [];
@@ -616,6 +626,7 @@ function TraceSearchView({
       onSelectTrace={onSelectTrace}
       onCompare={onCompare}
       onSearch={handleSearch}
+      onServiceChange={setPendingService}
     />
   );
 }

--- a/packages/ui/src/pages/observability.tsx
+++ b/packages/ui/src/pages/observability.tsx
@@ -28,12 +28,15 @@ import {
   KeyboardShortcutsProvider,
   useRegisterShortcuts,
   DynamicDashboard,
+  filtersKey,
 } from "../components/observability/index.js";
 import type { UITree } from "../components/observability/DynamicDashboard/index.js";
 import type {
   TraceSummary,
   TraceSearchFilters,
+  SearchFormValues,
 } from "../components/observability/index.js";
+import { useDebouncedValue } from "../components/observability/utils/use-debounced-value.js";
 
 import { SERVICES_SHORTCUTS } from "../components/observability/ServiceList/shortcuts.js";
 
@@ -489,6 +492,9 @@ interface TraceSummaryRow {
   services: Array<{ name: string; count: number; hasError: boolean }>;
 }
 
+/** Keyboard-arrowing a <select> fires one change per option passed over. */
+const OPERATIONS_DEBOUNCE_MS = 300;
+
 function TraceSearchView({
   onSelectTrace,
   onCompare,
@@ -575,26 +581,63 @@ function TraceSearchView({
   );
   const _services = servicesData?.services ?? [];
 
-  // Operations follow the service picked in the form, not the one in the URL:
-  // the URL only catches up on submit, and the user needs the operation list
-  // before that to build the search.
-  const [pendingService, setPendingService] = useState(service ?? "");
-  useEffect(() => {
-    setPendingService(service ?? "");
-  }, [service]);
+  // The committed search — what the URL currently describes. The form is seeded
+  // from this and rebuilt whenever it changes, so a submit or a back/forward
+  // can never leave one field holding a value from a different search.
+  const initialFilters = useMemo<SearchFormValues>(
+    () => ({
+      service: urlState.service ?? "",
+      operation: urlState.operation ?? "",
+      tags: urlState.tags ?? "",
+      lookback: urlState.lookback ?? "",
+      minDuration: urlState.minDuration ?? "",
+      maxDuration: urlState.maxDuration ?? "",
+      limit: urlState.limit ?? 20,
+    }),
+    [
+      urlState.service,
+      urlState.operation,
+      urlState.tags,
+      urlState.lookback,
+      urlState.minDuration,
+      urlState.maxDuration,
+      urlState.limit,
+    ]
+  );
+  const committedKey = filtersKey(initialFilters);
 
+  // Operations follow the service in the form, which starts from the committed
+  // search and then tracks the picker until the next submit — the user needs the
+  // list before submitting. Resetting during render rather than in an effect
+  // keeps the list and the picker consistent within a single commit.
+  const [draftService, setDraftService] = useState(initialFilters.service);
+  const [syncedKey, setSyncedKey] = useState(committedKey);
+  if (syncedKey !== committedKey) {
+    setSyncedKey(committedKey);
+    setDraftService(initialFilters.service);
+  }
+
+  // Arrowing through the picker fires a change event per service; only fetch for
+  // the one the user settles on.
+  const settledService = useDebouncedValue(
+    draftService,
+    OPERATIONS_DEBOUNCE_MS
+  );
   const operationDs = useMemo<DataSource | undefined>(
     () =>
-      pendingService
+      settledService
         ? {
             method: "getOperations" as const,
-            params: { serviceName: pendingService },
+            params: { serviceName: settledService },
           }
         : undefined,
-    [pendingService]
+    [settledService]
   );
   const { data: opsData } = useKopaiData<{ operations: string[] }>(operationDs);
-  const operations = opsData?.operations ?? [];
+  // Mid-debounce these still describe the previously settled service; offering
+  // them would let the user pick an operation the current service never emits.
+  const operations =
+    settledService === draftService ? (opsData?.operations ?? []) : [];
 
   // Map TraceSummaryRow → TraceSummary
   const traces = useMemo<TraceSummary[]>(() => {
@@ -618,7 +661,7 @@ function TraceSearchView({
   return (
     <TraceSearch
       services={_services}
-      service={service ?? ""}
+      initialFilters={initialFilters}
       traces={traces}
       operations={operations}
       isLoading={loading}
@@ -626,7 +669,7 @@ function TraceSearchView({
       onSelectTrace={onSelectTrace}
       onCompare={onCompare}
       onSearch={handleSearch}
-      onServiceChange={setPendingService}
+      onServiceChange={setDraftService}
     />
   );
 }


### PR DESCRIPTION
The operation dropdown fetched its list from `urlState.service`, but the search form owns the service picker in local state and only pushes to the URL on submit. Between picking a service and clicking Find Traces there was no service in the URL, so `getOperations` never fired and the dropdown sat empty — the user had to run a throwaway search first to populate it.

Track the in-progress selection in `pendingService` (seeded from and re-synced to the URL) and drive `getOperations` off that instead.

Two adjacent defects in the same interaction:

- Switching service kept the previously selected operation, filtering on a span name the new service never emits. Changing service now clears it.
- Submitting "All Services" fell back to the URL's service, so the filter could never be cleared. `service` was the only field using `?? service` where every sibling used `?? null`.

The operation picker is now disabled with "Select a service first" until a service is chosen, so the empty state reads as intentional.

Covers KOP-33. Regression tests assert operations load before submit, the stale operation clears on service change, and "All Services" drops both the URL param and the request's serviceName — all three fail without the corresponding fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Trace search operations now load when a service is selected.
  * The operation picker is disabled until a service is chosen and clears stale selections when the service changes.
  * Selecting “All Services” correctly removes the service filter.
  * Service changes are reflected without submitting a search.
  * Filters remain consistent when restored from the URL or browser history.
  * Operation options refresh smoothly when switching services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->