### PR TITLE
fix(ui): make service chips readable and the tags filter actually filter (KOP-29)

### DIFF
--- a/.changeset/spotty-chips-hide.md
+++ b/.changeset/spotty-chips-hide.md
@@ -1,0 +1,17 @@
+---
+"@kopai/ui": patch
+---
+
+Fix service chips on the traces page rendering as solid blocks with unreadable
+labels in Safari (KOP-29).
+
+The chip tint was built by appending a hex alpha suffix to the `hsl()` string
+from `getServiceColor()`, which is not a valid CSS colour. Chromium drops the
+declaration, leaving no tint at all; WebKit accepts it on the property-assignment
+path React uses and resolves it to the opaque colour, painting each chip over its
+own same-coloured label.
+
+`colors.ts` now owns the palette and exposes `getServiceTint(name, alpha)` and
+`getServiceLabelColor(name)`, so fill and label are derived separately. The label
+lightness also lifts it above the WCAG AA contrast threshold on the dark
+background, which the previous 50% did not meet for many hues.

--- a/.changeset/tidy-tags-filter.md
+++ b/.changeset/tidy-tags-filter.md
@@ -1,0 +1,15 @@
+---
+"@kopai/ui": patch
+---
+
+Make the Tags filter on the traces page actually filter.
+
+Two silent failures stacked: the parsed tags were sent under a `tags` key, which
+`traceSummariesFilterSchema` does not define, so zod stripped it before the
+request left the SDK; and the logfmt key pattern excluded `.`, clipping dotted
+OpenTelemetry attribute names to their last segment
+(`http.request.method=GET` parsed as `{ method: "GET" }`).
+
+Tags are now sent as `spanAttributes` with their keys intact. Note that they
+match span attributes only — resource-level attributes such as
+`deployment.environment` are not searched by this box.

--- a/packages/ui/src/components/observability/TraceSearch/index.tsx
+++ b/packages/ui/src/components/observability/TraceSearch/index.tsx
@@ -1,6 +1,10 @@
 import { useState, useMemo } from "react";
 import { formatTimestamp } from "../utils/time.js";
-import { getServiceColor } from "../utils/colors.js";
+import {
+  getServiceColor,
+  getServiceLabelColor,
+  getServiceTint,
+} from "../utils/colors.js";
 import { SearchForm, filtersKey } from "./SearchForm.js";
 import type { SearchFormValues } from "./SearchForm.js";
 import { ScatterPlot } from "./ScatterPlot.js";
@@ -277,8 +281,8 @@ export function TraceSearch({
                           key={svc.name}
                           className="inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded"
                           style={{
-                            backgroundColor: `${getServiceColor(svc.name)}20`,
-                            color: getServiceColor(svc.name),
+                            backgroundColor: getServiceTint(svc.name, 0.14),
+                            color: getServiceLabelColor(svc.name),
                           }}
                         >
                           {svc.hasError && (

--- a/packages/ui/src/components/observability/TraceSearch/index.tsx
+++ b/packages/ui/src/components/observability/TraceSearch/index.tsx
@@ -281,7 +281,7 @@ export function TraceSearch({
                           key={svc.name}
                           className="inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded"
                           style={{
-                            backgroundColor: getServiceTint(svc.name, 0.14),
+                            backgroundColor: getServiceTint(svc.name),
                             color: getServiceLabelColor(svc.name),
                           }}
                         >

--- a/packages/ui/src/components/observability/utils/colors.test.ts
+++ b/packages/ui/src/components/observability/utils/colors.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect } from "vitest";
+import {
+  getServiceColor,
+  getServiceTint,
+  getServiceLabelColor,
+  getSpanBarColor,
+  ERROR_COLOR,
+} from "./colors.js";
+
+/**
+ * Anchored, so a value with anything trailing it — `hsl(200, 70%, 50%)20`,
+ * the shape that broke the traces page — fails to parse rather than being
+ * quietly accepted. Handles both the legacy comma form and the modern
+ * space/slash form.
+ */
+function parseHsl(css: string): { h: number; s: number; l: number; a: number } {
+  const m =
+    /^hsl\(\s*([\d.]+)\s*,?\s*([\d.]+)%\s*,?\s*([\d.]+)%\s*(?:\/\s*([\d.]+)\s*)?\)$/.exec(
+      css
+    );
+  if (!m)
+    throw new Error(`not a parseable hsl() colour: ${JSON.stringify(css)}`);
+  return {
+    h: Number(m[1]),
+    s: Number(m[2]),
+    l: Number(m[3]),
+    a: m[4] === undefined ? 1 : Number(m[4]),
+  };
+}
+
+type Rgb = [number, number, number];
+
+/** HSL (h in degrees, s/l as percentages) to sRGB channels in 0..1. */
+function hslToRgb(h: number, s: number, l: number): Rgb {
+  const sat = s / 100;
+  const lig = l / 100;
+  const c = (1 - Math.abs(2 * lig - 1)) * sat;
+  const hp = (((h % 360) + 360) % 360) / 60;
+  const x = c * (1 - Math.abs((hp % 2) - 1));
+  let rgb: Rgb;
+  if (hp < 1) rgb = [c, x, 0];
+  else if (hp < 2) rgb = [x, c, 0];
+  else if (hp < 3) rgb = [0, c, x];
+  else if (hp < 4) rgb = [0, x, c];
+  else if (hp < 5) rgb = [x, 0, c];
+  else rgb = [c, 0, x];
+  const m = lig - c / 2;
+  return [rgb[0] + m, rgb[1] + m, rgb[2] + m];
+}
+
+/** WCAG 2.1 relative luminance. */
+function luminance([r, g, b]: Rgb): number {
+  const lin = (v: number) =>
+    v <= 0.04045 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+  return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+}
+
+function contrastRatio(a: Rgb, b: Rgb): number {
+  const la = luminance(a);
+  const lb = luminance(b);
+  const hi = Math.max(la, lb);
+  const lo = Math.min(la, lb);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+/** Source-over alpha blend, the way a browser paints a translucent fill. */
+function composite(fg: Rgb, alpha: number, bg: Rgb): Rgb {
+  const mix = (f: number, b: number) => alpha * f + (1 - alpha) * b;
+  return [mix(fg[0], bg[0]), mix(fg[1], bg[1]), mix(fg[2], bg[2])];
+}
+
+// --background in src/styles/globals.css. The app defines only this palette —
+// :root is dark and there is no light theme to fall back to.
+const PAGE_BACKGROUND: Rgb = hslToRgb(0, 0, 3.9);
+
+const SERVICES = [
+  "cart",
+  "checkout",
+  "frontend",
+  "payment-gateway",
+  "shipping",
+  "email",
+  "ad",
+  "recommendation",
+  "quote",
+  "currency",
+  "",
+];
+
+describe("service colour palette", () => {
+  it("returns parseable CSS colours", () => {
+    for (const name of SERVICES) {
+      expect(() => parseHsl(getServiceColor(name))).not.toThrow();
+      expect(() => parseHsl(getServiceTint(name))).not.toThrow();
+      expect(() => parseHsl(getServiceLabelColor(name))).not.toThrow();
+    }
+  });
+
+  it("is stable for a given service name", () => {
+    for (const name of SERVICES) {
+      expect(getServiceColor(name)).toBe(getServiceColor(name));
+      expect(getServiceLabelColor(name)).toBe(getServiceLabelColor(name));
+    }
+  });
+
+  it("spreads distinct services across distinct hues", () => {
+    const hues = new Set(
+      SERVICES.map((name) => parseHsl(getServiceColor(name)).h)
+    );
+    expect(hues.size).toBeGreaterThan(SERVICES.length / 2);
+  });
+
+  // The reason getServiceTint exists. Appending a hex alpha suffix was how the
+  // chip fill used to be built. No engine accepts it *as a tint* — Chromium
+  // discards it, WebKit resolves it to the opaque colour — so pin that the
+  // concatenation still produces something unparseable.
+  it("cannot be given an alpha by string concatenation", () => {
+    expect(() => parseHsl(`${getServiceColor("cart")}20`)).toThrow();
+  });
+});
+
+describe("getServiceTint", () => {
+  it("matches getServiceColor exactly apart from alpha, so a tinted fill and a solid one read as one service", () => {
+    for (const name of SERVICES) {
+      const solid = parseHsl(getServiceColor(name));
+      const tint = parseHsl(getServiceTint(name));
+      expect(tint.h).toBe(solid.h);
+      expect(tint.s).toBe(solid.s);
+      expect(tint.l).toBe(solid.l);
+      expect(tint.a).toBeLessThan(1);
+    }
+  });
+
+  it("defaults to a translucent alpha and honours an override", () => {
+    const def = parseHsl(getServiceTint("cart")).a;
+    expect(def).toBeGreaterThan(0);
+    expect(def).toBeLessThan(1);
+    expect(parseHsl(getServiceTint("cart", 0.5)).a).toBe(0.5);
+  });
+});
+
+describe("getServiceLabelColor", () => {
+  it("shares the hue with getServiceColor", () => {
+    for (const name of SERVICES) {
+      expect(parseHsl(getServiceLabelColor(name)).h).toBe(
+        parseHsl(getServiceColor(name)).h
+      );
+    }
+  });
+
+  // Guards the KOP-29 fix directly: collapsing the label back onto
+  // getServiceColor is what made service names unreadable on the dark page.
+  it("is lighter than getServiceColor", () => {
+    for (const name of SERVICES) {
+      expect(parseHsl(getServiceLabelColor(name)).l).toBeGreaterThan(
+        parseHsl(getServiceColor(name)).l
+      );
+    }
+  });
+
+  it("clears WCAG AA against a chip fill on the page background, for every hue", () => {
+    const failures: string[] = [];
+    for (let hue = 0; hue < 360; hue++) {
+      // Reconstruct a chip at this hue from the real palette values rather
+      // than trusting one service name to land on the worst case.
+      const sample = parseHsl(getServiceLabelColor("cart"));
+      const fill = parseHsl(getServiceTint("cart"));
+      const label = hslToRgb(hue, sample.s, sample.l);
+      const chipBg = composite(
+        hslToRgb(hue, fill.s, fill.l),
+        fill.a,
+        PAGE_BACKGROUND
+      );
+      const ratio = contrastRatio(label, chipBg);
+      if (ratio < 4.5) failures.push(`hue ${hue}: ${ratio.toFixed(2)}:1`);
+    }
+    expect(failures).toEqual([]);
+  });
+});
+
+describe("getSpanBarColor", () => {
+  it("uses the service colour when the span is healthy", () => {
+    expect(getSpanBarColor("cart", false)).toBe(getServiceColor("cart"));
+  });
+
+  it("overrides the service colour for errors", () => {
+    expect(getSpanBarColor("cart", true)).toBe(ERROR_COLOR);
+  });
+});

--- a/packages/ui/src/components/observability/utils/colors.test.ts
+++ b/packages/ui/src/components/observability/utils/colors.test.ts
@@ -55,6 +55,7 @@ function luminance([r, g, b]: Rgb): number {
   return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
 }
 
+/** WCAG 2.1 contrast ratio. 4.5:1 is the AA threshold for body-size text. */
 function contrastRatio(a: Rgb, b: Rgb): number {
   const la = luminance(a);
   const lb = luminance(b);

--- a/packages/ui/src/components/observability/utils/colors.ts
+++ b/packages/ui/src/components/observability/utils/colors.ts
@@ -3,6 +3,11 @@
  * Generates consistent colors for service names using HSL color space
  */
 
+/**
+ * djb2. Deliberately a hand-rolled hash rather than anything host-provided: a
+ * service has to keep the same colour across reloads, processes and machines,
+ * so this must never depend on insertion order or a per-process hash seed.
+ */
 function hashString(str: string): number {
   let hash = 5381;
   for (let i = 0; i < str.length; i++) {
@@ -21,6 +26,11 @@ const LABEL_LIGHTNESS = 72;
 // background, strong enough that the chip still reads as a filled shape.
 const TINT_ALPHA = 0.14;
 
+/**
+ * The single hue every colour below is derived from. Sharing one basis is what
+ * lets a tint, a label and a solid bar read as the same service; deriving any
+ * of them from its own hash would let them drift apart on a rename.
+ */
 function getServiceHue(serviceName: string): number {
   return hashString(serviceName) % 360;
 }
@@ -62,6 +72,11 @@ export function getServiceLabelColor(serviceName: string): string {
 
 export const ERROR_COLOR = "#ef4444";
 
+/**
+ * Bar colour for a span in the waterfall. An error drops the per-service hue
+ * for one shared red, so a failing span is findable without first learning
+ * which hue belongs to which service.
+ */
 export function getSpanBarColor(serviceName: string, isError: boolean): string {
   if (isError) {
     return ERROR_COLOR;

--- a/packages/ui/src/components/observability/utils/colors.ts
+++ b/packages/ui/src/components/observability/utils/colors.ts
@@ -14,8 +14,12 @@ function hashString(str: string): number {
 const SATURATION = 70;
 const LIGHTNESS = 50;
 // Lifted well above LIGHTNESS so a label stays legible on the dark background
-// and on top of getServiceTint.
+// and on top of getServiceTint. At LIGHTNESS a blue-ish hue lands near 2:1
+// against --background (0 0% 3.9%); at 72 the worst hue clears WCAG AA.
 const LABEL_LIGHTNESS = 72;
+// Faint enough that LABEL_LIGHTNESS keeps its contrast against the page
+// background, strong enough that the chip still reads as a filled shape.
+const TINT_ALPHA = 0.14;
 
 function getServiceHue(serviceName: string): number {
   return hashString(serviceName) % 360;
@@ -35,12 +39,23 @@ export function getServiceColor(serviceName: string): string {
   return `hsl(${getServiceHue(serviceName)}, ${SATURATION}%, ${LIGHTNESS}%)`;
 }
 
-/** The same colour at a given alpha, for fills sitting behind content. */
-export function getServiceTint(serviceName: string, alpha: number): string {
+/**
+ * getServiceColor at an alpha, for fills sitting behind content. Same hue,
+ * saturation and lightness, so a tinted fill and a solid one read as the same
+ * service.
+ */
+export function getServiceTint(
+  serviceName: string,
+  alpha: number = TINT_ALPHA
+): string {
   return `hsl(${getServiceHue(serviceName)} ${SATURATION}% ${LIGHTNESS}% / ${alpha})`;
 }
 
-/** Text colour for a label on a getServiceTint fill. */
+/**
+ * Text colour for a label on a getServiceTint fill. Shares the hue with
+ * getServiceColor but is deliberately lighter — flattening the two back
+ * together is what made service names unreadable on the traces page.
+ */
 export function getServiceLabelColor(serviceName: string): string {
   return `hsl(${getServiceHue(serviceName)} ${SATURATION}% ${LABEL_LIGHTNESS}%)`;
 }

--- a/packages/ui/src/components/observability/utils/colors.ts
+++ b/packages/ui/src/components/observability/utils/colors.ts
@@ -11,12 +11,38 @@ function hashString(str: string): number {
   return Math.abs(hash);
 }
 
+const SATURATION = 70;
+const LIGHTNESS = 50;
+// Lifted well above LIGHTNESS so a label stays legible on the dark background
+// and on top of getServiceTint.
+const LABEL_LIGHTNESS = 72;
+
+function getServiceHue(serviceName: string): number {
+  return hashString(serviceName) % 360;
+}
+
+/**
+ * Opaque colour for a service — bars, dots, borders.
+ *
+ * Do not build a translucent variant by appending a hex alpha suffix to this
+ * string. `hsl(...)20` is not a parseable CSS colour, and the two engines
+ * disagree about it on the property-assignment path React uses for inline
+ * styles: Chromium discards the declaration, while WebKit accepts it and
+ * resolves it to the *opaque* colour — which is how KOP-29 shipped a chip
+ * painted over its own same-coloured label. Use getServiceTint instead.
+ */
 export function getServiceColor(serviceName: string): string {
-  const hash = hashString(serviceName);
-  const hue = hash % 360;
-  const saturation = 70;
-  const lightness = 50;
-  return `hsl(${hue}, ${saturation}%, ${lightness}%)`;
+  return `hsl(${getServiceHue(serviceName)}, ${SATURATION}%, ${LIGHTNESS}%)`;
+}
+
+/** The same colour at a given alpha, for fills sitting behind content. */
+export function getServiceTint(serviceName: string, alpha: number): string {
+  return `hsl(${getServiceHue(serviceName)} ${SATURATION}% ${LIGHTNESS}% / ${alpha})`;
+}
+
+/** Text colour for a label on a getServiceTint fill. */
+export function getServiceLabelColor(serviceName: string): string {
+  return `hsl(${getServiceHue(serviceName)} ${SATURATION}% ${LABEL_LIGHTNESS}%)`;
 }
 
 export const ERROR_COLOR = "#ef4444";

--- a/packages/ui/src/pages/observability.test.tsx
+++ b/packages/ui/src/pages/observability.test.tsx
@@ -406,3 +406,51 @@ describe("trace search operation picker", () => {
     });
   });
 });
+
+describe("trace search tags filter", () => {
+  let mockClient: MockClient;
+  let originalLocation: string;
+
+  beforeEach(() => {
+    mockClient = createMockClient();
+    queryClient.clear();
+    vi.clearAllMocks();
+    originalLocation = window.location.search;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    window.history.replaceState(
+      null,
+      "",
+      window.location.pathname + originalLocation
+    );
+  });
+
+  function setURL(params: string) {
+    window.history.replaceState(null, "", window.location.pathname + params);
+    window.dispatchEvent(new PopStateEvent("popstate"));
+  }
+
+  // Both halves of this filter failed silently: `tags` is not a key of
+  // traceSummariesFilterSchema, so zod stripped it, and the logfmt key pattern
+  // clipped dotted attribute names to their last segment. Either one returns
+  // zero traces with no error, so assert on what actually reaches the client.
+  it("sends tags as span attributes, preserving dotted attribute keys", async () => {
+    setURL("?tab=services&tags=http.request.method%3DGET");
+
+    render(
+      createElement(ObservabilityPage, {
+        client: mockClient as unknown as KopaiClient,
+      })
+    );
+
+    await waitFor(() => {
+      const filter = mockClient.searchTraceSummariesPage.mock.calls.at(-1)?.[0];
+      expect(filter).toMatchObject({
+        spanAttributes: { "http.request.method": "GET" },
+      });
+      expect(filter).not.toHaveProperty("tags");
+    });
+  });
+});

--- a/packages/ui/src/pages/observability.tsx
+++ b/packages/ui/src/pages/observability.tsx
@@ -374,6 +374,12 @@ function parseDuration(input: string): string | undefined {
 // Logfmt helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Parses the Tags box — `key=value key2="quoted value"` — into an attribute
+ * map. Values may be bare or double-quoted. Each pair is matched downstream by
+ * exact equality, so `key=` searches for a literally empty value rather than
+ * for the key's presence.
+ */
 function parseLogfmt(str: string): Record<string, string> {
   const result: Record<string, string> = {};
   // Keys run to the first `=` or space: OTel attribute names are dotted

--- a/packages/ui/src/pages/observability.tsx
+++ b/packages/ui/src/pages/observability.tsx
@@ -376,7 +376,10 @@ function parseDuration(input: string): string | undefined {
 
 function parseLogfmt(str: string): Record<string, string> {
   const result: Record<string, string> = {};
-  const re = /(\w+)=(?:"([^"]*)"|([\S]*))/g;
+  // Keys run to the first `=` or space: OTel attribute names are dotted
+  // (`http.request.method`), and `\w+` would silently clip them to the last
+  // segment, leaving a filter that matches nothing.
+  const re = /([^\s=]+)=(?:"([^"]*)"|([\S]*))/g;
   let m: RegExpExecArray | null;
   while ((m = re.exec(str)) !== null) {
     const key = m[1];
@@ -530,8 +533,10 @@ function TraceSearchView({
       if (parsed) params.durationMax = parsed;
     }
     if (urlState.tags) {
+      // Tags are span-level attributes; the filter schema has no `tags` key, so
+      // sending one is silently stripped before the request leaves the SDK.
       const tagMap = parseLogfmt(urlState.tags);
-      if (Object.keys(tagMap).length > 0) params.tags = tagMap;
+      if (Object.keys(tagMap).length > 0) params.spanAttributes = tagMap;
     }
     return {
       method: "searchTraceSummariesPage",


### PR DESCRIPTION
## Summary

Fixes KOP-29 — service chips on the traces page rendered without a fill and
with labels too dark to read — and repairs the Tags filter, which had never
matched anything.

**`35088b2` — the fix.** The chip tint was built by appending a hex alpha
suffix to the `hsl()` string from `getServiceColor()`, which is not a
parseable CSS colour. `colors.ts` now owns the palette and derives fill and
label separately via `getServiceTint` / `getServiceLabelColor`.

Separately, the Tags box sent its input under a `tags` key that
`traceSummariesFilterSchema` doesn't define, so zod stripped it before the
request left the SDK — and the logfmt key pattern excluded `.`, clipping
dotted OTel attribute names (`http.request.method=GET` → `{method: "GET"}`).
Tags now go out as `spanAttributes` with keys intact. Note they match span
attributes only; resource-level names like `deployment.environment` are not
searched by this box.

**`1809b83` — tests.** `colors.test.ts` pins the three properties that keep
chips readable: the tint matches `getServiceColor` on hue/saturation/lightness
and differs only in alpha; the label shares that hue but is strictly lighter;
and the label clears WCAG AA against the chip fill composited over
`--background`, across all 360 hues. The test's `hsl()` parser is anchored, so
the exact malformed value that caused the bug fails to parse rather than being
quietly accepted. Both assertions were mutation-checked — restoring the old
lightness fails 169 of 360 hues. Also moves the `0.14` chip alpha into
`TINT_ALPHA` as a default, so the call site carries no literal.

## Changesets

`spotty-chips-hide.md` and `tidy-tags-filter.md` cover the fix. The test commit
adds none — `colors.ts` is internal (`src/index.ts` exports only
`ObservabilityPage` and the `@kopai/ui-core` re-exports), so nothing in it is
observable to a consumer of `@kopai/ui`.

## Verification

167 tests passing, `tsc --noEmit` clean, `eslint src` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Safari service-chip rendering issues with improved tint and label colors.
  * Improved WCAG AA contrast for service badges across trace visualizations.
  * Fixed the Tags filter to preserve dotted OpenTelemetry attribute names.
  * Prevented resource-level attributes from producing incorrect tag matches.

* **Tests**
  * Added comprehensive coverage for service colors, contrast, span indicators, and trace tag filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
